### PR TITLE
core: fix parsing of external HTTP documents

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -82,7 +82,7 @@ class API {
     let absPath = paths.shift();
 
     while (typeof absPath !== 'undefined') {
-      if (absPath === path.resolve(this.filepath)) {
+      if (absPath === this.filepath || absPath === path.resolve(this.filepath)) {
         mainReference = absPath;
       } else {
         const content = $refs.get(absPath);

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -50,6 +50,28 @@ describe('API definition class', () => {
     });
   });
 
+  describe('with an http file containing relative URL refs', () => {
+    test
+      .nock('http://example.org', (api) =>
+        api
+          .get('/openapi')
+          .replyWithFile(200, 'examples/valid/openapi.v3.json', {
+            'Content-Type': 'application/json',
+          })
+          .get('/schemas/all.yml')
+          .replyWithFile(200, 'examples/valid/schemas/all.yml', {
+            'Content-Type': 'application/yaml',
+          }),
+      )
+      .it('parses external file successfully', async () => {
+        const api = await API.loadAPI('http://example.org/openapi');
+        expect(api.version).to.equal('3.0.2');
+        expect(api.references.map((ref) => ref.location)).to.contain(
+          'http://example.org/schemas/all.yml',
+        );
+      });
+  });
+
   describe('with an invalid definition file', () => {
     for (const [example, error] of Object.entries({
       './examples/invalid/openapi.yml': 'Unsupported API specification',


### PR DESCRIPTION
This commit fixes the parsing of files provided from a URL string
instead of a local disk filepath.

It introduces a test case to make sure this feature works well too.

**Depends on #8 to be merged first**