### PR TITLE
validate: add a `--dry-run` flag to the `bump deploy` command

### DIFF
--- a/examples/invalid/asyncapi.yml
+++ b/examples/invalid/asyncapi.yml
@@ -1,0 +1,8 @@
+{
+  "info": {
+    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
+    "title": "Bump Api",
+    "version": "1.0"
+  },
+  "asyncapi": "2.0.0",
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -42,6 +42,15 @@ class BumpApi {
     });
   };
 
+  public postValidation = (
+    body: VersionRequest,
+    token: string,
+  ): Promise<AxiosResponse<void>> => {
+    return this.client.post<void>('/validations', body, {
+      headers: this.authorizationHeader(token),
+    });
+  };
+
   private initializeResponseInterceptor = () => {
     this.client.interceptors.response.use((data) => data, this.handleError);
   };

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -53,4 +53,12 @@ const autoCreate = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
   });
 };
 
-export { doc, docName, hub, token, autoCreate };
+const dryRun = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
+  return flags.boolean({
+    description:
+      'Validate a new documentation version. Does everything a normal deploy would do except publishing the new version. Useful in automated environments such as test platforms or continuous integration. Default: false',
+    ...options,
+  });
+};
+
+export { doc, docName, hub, token, autoCreate, dryRun };


### PR DESCRIPTION
_⚠️ Needs #10 to be merged first as its included in this PR_

This is the equivalent to the old CLI `validate` command. It didn't
make much sense to have a completely separate command for it as it's
actually only doing a “preview” of an actual deploy by validating the
given definition file.

Note: There's one small subtility in this PR. The current /validations
API endpoint always for non “dry-run” actions with the
auto_create_documentation parameter. Thus keeping the 'auto create'
feature when calling `bump deploy --dry-run` didn't make sense. I have
thus made sure to avoid the possibility to auto create a documentation
with this flag.

Closes #2
