### PR TITLE
fix: resolve relative ref locations for URLs API definitions

### DIFF
--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -66,9 +66,7 @@ describe('API definition class', () => {
       .it('parses external file successfully', async () => {
         const api = await API.loadAPI('http://example.org/openapi');
         expect(api.version).to.equal('3.0.2');
-        expect(api.references.map((ref) => ref.location)).to.contain(
-          'http://example.org/schemas/all.yml',
-        );
+        expect(api.references.map((ref) => ref.location)).to.contain('schemas/all.yml');
       });
   });
 


### PR DESCRIPTION
This fixes the relative refs for API definitions that come from a URL.

It extracts the relative path computation logic in a dedicated
function `resolveRelativeLocation` which now supports both FILE
relative paths and URL relative paths.

This avoids sending URLs in `references` sent to our API but instead
sends relative paths to the main API def.

With this fix, the CLI can now generate correct documentations on Bump
for this kind of definition:

https://gitlab.com/gitlab-org/gitlab/-/raw/54edee77f48dafbd16c51e1ab479b8dac7dc7d94/doc/api/openapi/openapi.yaml