### PR TITLE
doc: update README to document the `--dry-run` flag of deploy cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ If you already have a hub in your [Bump.sh](https://bump.sh) account, you can au
 $ bump deploy path/to/your/file.yml --auto-create --doc DOC_SLUG --hub HUB_ID_OR_SLUG --token HUB_TOKEN
 ```
 
+Simulate a deployment of your definition file to make sure it is valid with the `--dry-run` flag, it is particularly useful in a Continuous Integration environment running a test deployment outside your main branch:
+
+```sh-session
+$ bump deploy path/to/your/file.yml --dry-run --doc DOC_ID_OR_SLUG --token DOC_TOKEN
+```
+
 Please check `bump deploy --help` for more usage details
 
 ## Development

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -11,15 +11,21 @@ export default class Deploy extends Command {
   static examples = [
     `Deploy a new version of an existing documentation
 
-$> bump deploy FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
+$ bump deploy FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
 * Let's deploy a new documentation version on Bump... done
 * Your new documentation version will soon be ready
 `,
     `Deploy a new version of an existing documentation attached to a hub
 
-$> bump deploy FILE --doc <doc_slug> --hub <your_hub_id_or_slug> --token <your_doc_token>
+$ bump deploy FILE --doc <doc_slug> --hub <your_hub_id_or_slug> --token <your_doc_token>
 * Let's deploy a new documentation version on Bump... done
 * Your new documentation version will soon be ready
+`,
+    `Validate a new documentation version before deploying it
+
+$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
+* Let's validate a new documentation version on Bump... done
+* Definition is valid
 `,
   ];
 


### PR DESCRIPTION
This documentation update was forgotten in #16