### PR TITLE
core: parse raw file definition to send to the API

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -27,7 +27,7 @@ export default abstract class Command extends Base {
     return debug(`bump-cli:command:${this.constructor.name.toLowerCase()}`)(message);
   }
 
-  async prepareDefinition(filepath: string): Promise<[API, Reference[]]> {
+  async prepareDefinition(filepath: string): Promise<[string, Reference[]]> {
     const api = await API.loadAPI(filepath);
     const references = [];
 
@@ -37,10 +37,10 @@ export default abstract class Command extends Base {
       const reference = api.references[i];
       references.push({
         location: reference.location,
-        content: JSON.stringify(reference.content),
+        content: reference.content,
       });
     }
 
-    return [api, references];
+    return [api.rawDefinition, references];
   }
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -49,7 +49,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
   */
   async run(): Promise<void> {
     const { args, flags } = this.parse(Deploy);
-    const [api, references] = await this.prepareDefinition(args.FILE);
+    const [definition, references] = await this.prepareDefinition(args.FILE);
     const action = flags['dry-run'] ? 'validate' : 'deploy';
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const [documentation, token] = [flags.doc!, flags.token!];
@@ -61,7 +61,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
       hub: flags.hub,
       documentation_name: flags['doc-name'],
       auto_create_documentation: flags['auto-create'] && !flags['dry-run'],
-      definition: JSON.stringify(api.definition),
+      definition,
       references,
     };
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -21,12 +21,12 @@ export default class Preview extends Command {
 
   async run(): Promise<void> {
     const { args } = this.parse(Preview);
-    const [api, references] = await this.prepareDefinition(args.FILE);
+    const [definition, references] = await this.prepareDefinition(args.FILE);
 
     cli.action.start("* Let's render a preview on Bump");
 
     const request: PreviewRequest = {
-      definition: JSON.stringify(api.definition),
+      definition,
       references,
     };
     const response: { data: PreviewResponse } = await this.bump.postPreview(request);

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -74,7 +74,7 @@ describe('API definition class', () => {
     for (const [example, error] of Object.entries({
       './examples/invalid/openapi.yml': 'Unsupported API specification',
       './examples/invalid/array.yml': 'Unsupported API specification',
-      './examples/invalid/string.yml': 'not a valid JSON Schema',
+      './examples/invalid/string.yml': 'Unsupported API specification',
     })) {
       test
         .do(async () => await API.loadAPI(example))

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -10,5 +10,8 @@ declare module '@asyncapi/specs' {
   export default asyncapi;
 }
 
+// Internals of json-schema-ref-parser doesn't expose types
+declare module '@apidevtools/json-schema-ref-parser/lib/options';
+
 // Load repo root level package.json file
 declare module '*.json';


### PR DESCRIPTION
The Bump API expects a raw string containing the definition content in
plain string. Right now the CLI serializes the parsed file/URL to JSON
before sending it to Bump.

However we used to always send the raw file content to our API so we
continue to do so for the main api definition with this commit.

Note: Even if we send the raw main definition, please note that
references resolved by the CLI will now always be sent serialized in
JSON.