### PR TITLE
fix: resolve accented filesystem path correctly in $RefParser lib

### DIFF
--- a/examples/valid/__gitlab-é__.yml
+++ b/examples/valid/__gitlab-é__.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  description: |
+    An OpenAPI definition for the GitLab REST API.
+  version: v4
+  title: GitLab API
+
+paths:
+  # ...
+
+
+  # ACCESS REQUESTS (PROJECTS)
+  /v4/projects/{id}/access_requests:
+    $ref: 'v4/access_requests.yaml#/accessRequestsProjects'
+
+  # ...

--- a/examples/valid/v4/access_requests.yaml
+++ b/examples/valid/v4/access_requests.yaml
@@ -1,0 +1,12 @@
+accessRequestsProjects:
+  get:
+    description: Lists access requests for a project
+    parameters:
+      - name: id
+        in: path
+    responses:
+      '200':
+        description: Successful operation
+        content:
+          'application/json':
+            $ref: 'models/ProjectAccessResponse.yaml'

--- a/examples/valid/v4/models/ProjectAccessResponse.yaml
+++ b/examples/valid/v4/models/ProjectAccessResponse.yaml
@@ -1,0 +1,11 @@
+schema:
+  title: ProjectAccessResponse
+  type: object
+  properties:
+    id:
+      type: integer
+    usename:
+      type: string
+example:
+  - "id": 1
+    "username": "raymond_smith"

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -50,6 +50,13 @@ describe('API definition class', () => {
     });
   });
 
+  describe('with a file path containing special characters', () => {
+    test.it('parses successfully', async () => {
+      const api = await API.loadAPI('./examples/valid/__gitlab-é__.yml');
+      expect(api.version).to.equal('3.0.0');
+    });
+  });
+
   describe('with an http file containing relative URL refs', () => {
     test
       .nock('http://example.org', (api) =>


### PR DESCRIPTION
The internal `$refs` Class of the json-schema-ref-parser library stores
paths in a URI encoded fashion. This is to prevent confusion between #
hash internal references (mentioned in the full json path) and #
characters in the filesystem path.

This commit makes sure to fetch the parsed values from the `$refs`
object from the `$refs.values()` function (instead of the
`$refs.get($ref)` function).

I got a bit confused with the internals of the lib as I expected to be
able to provide the returned values of `$Refs.paths()` to the
`$Refs.get()` function transparently. But this does not work for
filesystem paths containing special characters. The best solution is
thus to fetch the `$refs.values()` object which has decoded file path
as keys. I.e. exactly what we need.