### PR TITLE
core: add release step in CI to push packed tarballs to GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+on:
+  workflow_run:
+    workflows: [ "Developer checks" ]
+    types: [ completed ]
+jobs:
+  # This 'check_tag' job is a hack because Github doesn't provide the full ref from the
+  # original triggered workflow. Hopefully in the future we will only have to change
+  # the condition of the `release` job to:
+  #
+  # ${{ github.event.workflow_run.conclusion == 'success' &&
+  #   startsWith(github.event.workflow_run, 'refs/tag/v') }}
+  check_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      run_release: ${{ steps.check-tag.outputs.run_jobs }}
+      tag: ${{ steps.check-tag.outputs.ref }}
+    steps:
+      - name: check reference of dependent workflow ${{ github.event.workflow_run.head_branch }}
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.workflow_run.head_branch }} =~ v[0-9]+\.[0-9]+\.[0-9]+.* ]]; then
+            echo "::set-output name=run_jobs::true"
+            echo "::set-output name=ref::${{ github.event.workflow_run.head_branch }}"
+          else
+            echo "::set-output name=run_jobs::false"
+          fi
+  release:
+    needs: [check_tag]
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.check_tag.outputs.run_release == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [ '15' ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.check_tag.outputs.tag }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: node-${{ matrix.node_version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            node-${{ matrix.node_version }}-build-${{ env.cache-name }}-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+      - run: npm ci
+      - run: npm run pack
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/**/*
+          draft: true
+          tag_name: ${{ needs.check_tag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: bump-sh/cli

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && npm run build && oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run clean && npm run build && npm run lint",
-    "publish": "np",
+    "publish": "np --no-release-draft",
     "test": "mocha \"test/**/*.test.ts\"",
     "test-coverage": "nyc npm run test",
     "test-integration": "node ./test/integration.js",


### PR DESCRIPTION
As part of #18 this is a test to try to push tarballs generated by
oclif to a Github Release.

The idea for the release process would be in two steps:

1. locally on a developer machine: bump the version, commit, tag and
  publish to npm with the following command:

  ```
  npm run publish -- 2.0.1
  ```

  This will not create a github release anymore (due to the added
  `--no-release-draft` tag passed to `np`).

2. once the tag is pushed, the CI kicks in with this [github action](https://github.com/softprops/action-gh-release)
  by doing the following:
  - Github draft release creation
  - Upload of standalone tarballs (generated by oclif)

3. The developer needs to edit the newly created draft release to
  write release notes and publish the github release 🚀