### PR TITLE
preview: add a flag to open the URL in a browser directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ ARGUMENTS
   FILE  Path or URL to your API documentation file. OpenAPI (2.0 to 3.1.0) and AsyncAPI (2.0)
         specifications are currently supported.
 
+OPTIONS
+  -o, --open  Open the generated preview URL in your browser
+
 EXAMPLE
-  $ bump preview my-api-file.json
+  $ bump preview FILE
   * Your preview is visible at: https://bump.sh/preview/45807371-9a32-48a7-b6e4-1cb7088b5b9b
 ```
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -15,12 +15,17 @@ export default class Preview extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
+    open: flags.boolean({
+      char: 'o',
+      default: false,
+      description: 'Open the generated preview URL in your browser',
+    }),
   };
 
   static args = [fileArg];
 
   async run(): Promise<void> {
-    const { args } = this.parse(Preview);
+    const { args, flags } = this.parse(Preview);
     const [definition, references] = await this.prepareDefinition(args.FILE);
 
     cli.action.start("* Let's render a preview on Bump");
@@ -36,6 +41,10 @@ export default class Preview extends Command {
     cli.styledSuccess(
       `Your preview is visible at: ${response.data.public_url} (Expires at ${response.data.expires_at})`,
     );
+
+    if (flags.open && response.data.public_url) {
+      await cli.open(response.data.public_url);
+    }
 
     return;
   }


### PR DESCRIPTION
This is a small addition to help open up a preview directly in your
browser.