### PR TITLE
feature: add a `diff` command to be able to retrieve a doc change

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,22 @@ COMMANDS
 
 * [`bump preview [FILE]`](#bump-preview-file)
 * [`bump deploy [FILE]`](#bump-deploy-file)
+* [`bump diff [FILE]`](#bump-diff-file)
 
 ### `bump preview [FILE]`
 
-You can preview your documentation by calling the `preview` command. A temporary preview will be created with a unique URL. This preview will be available for 30 minutes. You don't need any credentials to use this command.
+You can preview your documentation by calling the `preview` command. A temporary preview will be created with a unique URL. This preview will be available for 30 minutes. You don't need any credentials to use this command. Here is an example usage:
 
+
+```sh-session
+$ bump preview https://bit.ly/asyncapi
+* Let's render a preview on Bump... done
+* Your preview is visible at: https://bump.sh/preview/c192dad0-79d7-44b3-b5e1-244b69f618e4 (Expires at 2021-06-28T18:06:56+02:00)
 ```
-USAGE
-  $ bump preview FILE
 
-ARGUMENTS
-  FILE  Path or URL to your API documentation file. OpenAPI (2.0 to 3.1.0) and AsyncAPI (2.0)
-        specifications are currently supported.
+_Note: you can use the `--open` flag to open the preview URL in your browser directly._
 
-OPTIONS
-  -o, --open  Open the generated preview URL in your browser
-
-EXAMPLE
-  $ bump preview FILE
-  * Your preview is visible at: https://bump.sh/preview/45807371-9a32-48a7-b6e4-1cb7088b5b9b
-```
+Please check `bump preview --help` for more usage details
 
 ### `bump deploy [FILE]`
 
@@ -104,6 +100,24 @@ $ bump deploy path/to/your/file.yml --dry-run --doc DOC_ID_OR_SLUG --token DOC_T
 ```
 
 Please check `bump deploy --help` for more usage details
+
+### `bump diff [FILE]`
+
+_If you want to receive automatic `bump diff` results on your Github Pull Requests you might be interested by [our Github Action](https://github.com/marketplace/actions/api-documentation-on-bump#diff) diff command._
+
+From a Bump documentation, the `diff` command will retrieve a comparaison changelog between your existing documentation and the given file or URL:
+
+```sh-session
+$ bump diff path/to/your/file.yml --doc DOC_ID_OR_SLUG --token DOC_TOKEN
+* Let's compare the given definition version... done
+
+Updated: POST /validations
+  Body attribute modified: documentation
+```
+
+_Note: you can use the `--open` flag to open the visual diff URL in your browser directly._
+
+Please check `bump diff --help` for full usage details.
 
 ## Development
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,6 +33,15 @@ class BumpApi {
     return this.client.get<PingResponse>('/ping');
   };
 
+  public getVersion = (
+    versionId: string,
+    token: string,
+  ): Promise<AxiosResponse<VersionResponse>> => {
+    return this.client.get<VersionResponse>(`/versions/${versionId}`, {
+      headers: this.authorizationHeader(token),
+    });
+  };
+
   public postPreview = (
     body?: PreviewRequest,
   ): Promise<AxiosResponse<PreviewResponse>> => {

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -34,9 +34,12 @@ export interface VersionRequest {
   documentation_name?: string;
   auto_create_documentation?: boolean;
   references?: Reference[];
+  unpublished?: boolean;
 }
 
 export interface VersionResponse {
   id: string;
   doc_public_url?: string;
+  diff_public_url?: string;
+  diff_summary?: string;
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -10,6 +10,10 @@ export default abstract class Command extends Base {
   private base = `${pjson.name}@${pjson.version}`;
   _bump!: BumpApi;
 
+  get pollingPeriod(): number {
+    return 1000;
+  }
+
   get bump(): BumpApi {
     if (!this._bump) this._bump = new BumpApi(this.config);
     return this._bump;
@@ -23,8 +27,22 @@ export default abstract class Command extends Base {
     throw error;
   }
 
-  d(message: string): void {
-    return debug(`bump-cli:command:${this.constructor.name.toLowerCase()}`)(message);
+  // Function signature type taken from @types/debug
+  // Debugger(formatter: any, ...args: any[]): void;
+  /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any */
+  d(formatter: any, ...args: any[]): void {
+    return debug(`bump-cli:command:${this.constructor.name.toLowerCase()}`)(
+      formatter,
+      ...args,
+    );
+  }
+
+  async pollingDelay(): Promise<void> {
+    return await this.delay(this.pollingPeriod);
+  }
+
+  private async delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   async prepareDefinition(filepath: string): Promise<[string, Reference[]]> {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -85,7 +85,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
         );
         break;
       case 204:
-        this.warn('Your documentation has not changed!');
+        this.warn('Your documentation has not changed');
         break;
     }
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,0 +1,133 @@
+import { CLIError } from '@oclif/errors';
+
+import Command from '../command';
+import * as flags from '../flags';
+import { fileArg } from '../args';
+import { cli } from '../cli';
+import { VersionRequest, VersionResponse } from '../api/models';
+
+export default class Diff extends Command {
+  static description =
+    'Get a comparaison diff with your documentation from the given file or URL';
+
+  static examples = [
+    `Compare a potential new version with the currently published one:
+
+  $ bump diff FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
+  * Let's compare the given definition version... done
+  Removed: GET /compare
+  Added: GET /versions/{versionId}
+`,
+    `Store the diff in a dedicated file:
+
+  $ bump diff FILE --doc <doc_slug> --token <doc_token> > /tmp/my-saved-diff
+  * Let's compare the given definition version... done
+
+  $ cat /tmp/my-saved-diff
+  Removed: GET /compare
+  Added: GET /versions/{versionId}
+`,
+    `In case of a non modified definition FILE compared to your existing documentation, no changes are output:
+
+  $ bump diff FILE --doc <doc_slug> --token <your_doc_token>
+  * Let's compare the given definition version... done
+   ›   Warning: Your documentation has not changed
+`,
+  ];
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    doc: flags.doc(),
+    hub: flags.hub(),
+    token: flags.token(),
+    open: flags.open({ description: 'Open the visual diff in your browser' }),
+  };
+
+  static args = [fileArg];
+
+  /*
+    Oclif doesn't type parsed args & flags correctly and especially
+    required-ness which is not known by the compiler, thus the use of
+    the non-null assertion '!' in this command.
+    See https://github.com/oclif/oclif/issues/301 for details
+  */
+  async run(): Promise<VersionResponse | void> {
+    const { args, flags } = this.parse(Diff);
+    const [definition, references] = await this.prepareDefinition(args.FILE);
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+    const [documentation, token] = [flags.doc!, flags.token!];
+
+    cli.action.start("* Let's compare the given definition version");
+
+    const request: VersionRequest = {
+      documentation,
+      hub: flags.hub,
+      definition,
+      references,
+      unpublished: true,
+    };
+
+    const response = await this.bump.postVersion(request, token);
+    switch (response.status) {
+      case 201:
+        let version: VersionResponse = response.data;
+        this.d(`Unpublished version created with ID ${version.id}`);
+
+        version = await this.waitChangesResult(version.id, token, {
+          timeout: 30,
+        });
+        cli.action.stop();
+
+        if (version && version.diff_summary) {
+          await cli.log(version.diff_summary);
+          if (flags.open && version.diff_public_url) {
+            await cli.open(version.diff_public_url);
+          }
+        } else {
+          this.warn('There were no structural changes in your new definition');
+        }
+
+        return version;
+        break;
+      case 204:
+        cli.action.stop();
+        this.warn('Your documentation has not changed');
+        break;
+    }
+
+    return;
+  }
+
+  async waitChangesResult(
+    versionId: string,
+    token: string,
+    opts: { timeout: number },
+  ): Promise<VersionResponse> {
+    const diffResponse = await this.bump.getVersion(versionId, token);
+
+    if (opts.timeout <= 0) {
+      throw new CLIError(
+        'We were unable to compute your documentation diff. Sorry about that. Please try again later',
+      );
+    }
+
+    switch (diffResponse.status) {
+      case 200:
+        const version: VersionResponse = diffResponse.data;
+
+        this.d(`Received version:`);
+        this.d(version);
+        return version;
+        break;
+      case 202:
+        this.d('Waiting 1 sec before next pool');
+        await this.pollingDelay();
+        return await this.waitChangesResult(versionId, token, {
+          timeout: opts.timeout - 1,
+        });
+        break;
+    }
+
+    return {} as VersionResponse;
+  }
+}

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -15,11 +15,7 @@ export default class Preview extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    open: flags.boolean({
-      char: 'o',
-      default: false,
-      description: 'Open the generated preview URL in your browser',
-    }),
+    open: flags.open({ description: 'Open the generated preview URL in your browser' }),
   };
 
   static args = [fileArg];

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -61,4 +61,12 @@ const dryRun = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
   });
 };
 
-export { doc, docName, hub, token, autoCreate, dryRun };
+const open = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
+  return flags.boolean({
+    char: 'o',
+    default: false,
+    ...options,
+  });
+};
+
+export { doc, docName, hub, token, autoCreate, dryRun, open };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { run } from '@oclif/command';
+import Diff from './commands/diff';
 import Deploy from './commands/deploy';
 import Preview from './commands/preview';
+import { VersionResponse } from './api/models';
 
-export { run, Deploy, Preview };
+export { run, Deploy, Diff, Preview, VersionResponse };

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -30,7 +30,7 @@ describe('deploy subcommand', () => {
       .command(['deploy', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
       .it('sends unchanged version to Bump', ({ stderr }) => {
         expect(stderr).to.contain("Let's deploy a new documentation version");
-        expect(stderr).to.contain('Your documentation has not changed!');
+        expect(stderr).to.contain('Your documentation has not changed');
       });
 
     test

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -1,0 +1,159 @@
+import base, { expect } from '@oclif/test';
+import nock from 'nock';
+import * as sinon from 'sinon';
+import Command from '../../src/command';
+
+nock.disableNetConnect();
+
+const test = base.env({ BUMP_TOKEN: 'BAR' });
+
+describe('diff subcommand', () => {
+  let pollingStub: sinon.SinonStub;
+  beforeEach(() => {
+    pollingStub = sinon.stub(Command.prototype, 'pollingPeriod');
+    pollingStub.get(() => 0);
+  });
+
+  afterEach(() => {
+    pollingStub.restore();
+  });
+
+  describe('Successful runs', () => {
+    test
+      .nock('https://bump.sh', (api) => {
+        api
+          .post('/api/v1/versions')
+          .once()
+          .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
+          .get('/api/v1/versions/123')
+          .once()
+          .reply(202)
+          .get('/api/v1/versions/123')
+          .once()
+          .reply(200, { diff_summary: 'Updated: POST /versions' });
+      })
+      .stdout()
+      .stderr()
+      .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+      .it('asks for a diff to Bump', async ({ stdout, stderr }) => {
+        expect(stderr).to.match(/Let's compare the given definition version/);
+        expect(stdout).to.contain('Updated: POST /versions');
+      });
+
+    test
+      .nock('https://bump.sh', (api) => {
+        api
+          .post('/api/v1/versions')
+          .once()
+          .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
+          .get('/api/v1/versions/123')
+          .once()
+          .reply(200, {});
+      })
+      .stdout()
+      .stderr()
+      .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+      .it('asks for a diff with content change only', async ({ stdout, stderr }) => {
+        expect(stderr).to.match(/Let's compare the given definition version/);
+        expect(stderr).to.contain('no structural changes in your new definition');
+        expect(stdout).to.eq('');
+      });
+
+    test
+      .nock('https://bump.sh', (api) => {
+        api.post('/api/v1/versions').once().reply(204, {});
+      })
+      .stdout()
+      .stderr()
+      .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+      .it('notifies an unchanged definition', async ({ stdout, stderr }) => {
+        expect(stderr).to.match(/Let's compare the given definition version/);
+        expect(stderr).to.contain('Your documentation has not changed');
+        expect(stdout).to.eq('');
+      });
+  });
+
+  describe('Server errors', () => {
+    describe('Authentication error', () => {
+      test
+        .nock('https://bump.sh', (api) => api.post('/api/v1/versions').reply(401))
+        .stdout()
+        .stderr()
+        .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+        .catch((err) => {
+          expect(err.message).to.contain('not allowed to deploy');
+          throw err;
+        })
+        .exit(101)
+        .it("Doesn't create a diff version");
+    });
+
+    describe('Not found error', () => {
+      test
+        .nock('https://bump.sh', (api) => api.post('/api/v1/versions').reply(404))
+        .stdout()
+        .stderr()
+        .command(['deploy', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+        .catch((err) => {
+          expect(err.message).to.contain(
+            "It seems the documentation provided doesn't exist",
+          );
+          throw err;
+        })
+        .exit(104)
+        .it("Doesn't create a diff version");
+    });
+
+    describe('Timeout reached while polling for results', () => {
+      test
+        .nock('https://bump.sh', (api) => {
+          api
+            .post('/api/v1/versions')
+            .once()
+            .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
+            .get('/api/v1/versions/123')
+            .times(31)
+            .reply(202);
+        })
+        .stdout()
+        .stderr()
+        .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+        .catch((err) => {
+          expect(err.message).to.contain(
+            'We were unable to compute your documentation diff',
+          );
+          throw err;
+        })
+        .exit(2)
+        .it('asks for a diff to Bump', async ({ stdout, stderr }) => {
+          expect(stderr).to.match(/Let's compare the given definition version/);
+          expect(stdout).to.eq('');
+        });
+    });
+  });
+
+  describe('User bad usages', () => {
+    test
+      .command(['diff', 'FILE', '--doc', 'coucou'])
+      .catch((err) => expect(err.message).to.match(/no such file or directory/))
+      .it('Fails diff of an inexistant file');
+
+    test
+      .command(['diff'])
+      .exit(2)
+      .it('exits with status 2 when no file argument is provided');
+
+    test
+      .command(['diff', 'examples/valid/openapi.v3.json'])
+      .catch((err) => expect(err.message).to.match(/missing required flag(.|\n)+--doc/im))
+      .it('fails when no documentation id or slug is provided');
+
+    test
+      .env({ BUMP_TOKEN: '' }, { clear: true })
+      .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+      .catch((err) =>
+        expect(err.message).to.match(/missing required flag(.|\n)+--token/im),
+      )
+      .it('fails when no access token is provided');
+  });
+});


### PR DESCRIPTION
This is a new command `bump diff` which allow to fetch a documentation
change between an existing documentation and a provided definition
FILE.

```
Get a comparaison diff with your documentation from the given file or URL

USAGE
  $ bump diff FILE

ARGUMENTS
  FILE  Path or URL to your API documentation file. OpenAPI (2.0 to 3.1.0) and AsyncAPI (2.0)
        specifications are currently supported.

OPTIONS
  -b, --hub=hub      Hub id or slug. Can be provided via BUMP_HUB_ID environment variable

  -d, --doc=doc      (required) Documentation public id or slug. Can be provided via BUMP_ID environment
                     variable

  -h, --help         show CLI help

  -t, --token=token  (required) Documentation or Hub token. Can be provided via BUMP_TOKEN environment
                     variable

EXAMPLES
  Compare a potential new version with an existing documentation.

  $ bump diff FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
  * Let's compare the given definition version... done
  Removed: GET /compare
  Added: GET /versions/{versionId}/changes

  Compare a non modified definition FILE with an existing documentation

  $ bump diff FILE --doc <doc_slug> --token <your_doc_token>
  * Let's compare the given definition version... done
    ›   Warning: Your documentation has not changed!


```

For now it uses polling mechanism (a http request every second for max
30 seconds) to fetch the diff result. We should later expose a
websocket public API so the CLI can simply listen to events coming
from the WS for deploy status.

## Demo

**`git diff`** on our openapi.yml spec
```
> git diff
diff --git a/doc/api/v1/openapi.v3.yml b/doc/api/v1/openapi.v3.yml
index af8a1d743..c311d7808 100644
--- a/doc/api/v1/openapi.v3.yml
+++ b/doc/api/v1/openapi.v3.yml
@@ -216,10 +216,6 @@ components:
           type: string
           description: "Unique id of your newly deployed version."
           example: 2361df99-3467-4c80-a0cc-45c9fe565812
-        doc_id:
-          type: string
-          description: "Unique id of your documentation."
-          example: 3ef8f52f-9056-4113-840e-2f7183b90e06
         doc_public_url:
           type: string
           description: "The public URL of your documentation."
```

**`bump diff`**
```
> time BUMP_TOKEN=123abc BUMP_HOST=http://localhost:3000/ ./bin/run diff -d bump --hub yoyo ../bump/doc/api/v1/openapi.v3.yml                    
* Let's compare the given definition version... done
Updated: POST /versions
  Response modified: 201
    Body attribute removed: doc_id

real    0m5,487s
user    0m1,505s
sys     0m0,104s
```