### PR TITLE
api(bump): 'id' attribute is always present in both previews & versions responses

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -7,7 +7,7 @@ export interface PingResponse {
 }
 
 export interface PreviewResponse {
-  id?: string;
+  id: string;
   expires_at?: string;
   public_url?: string;
 }

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -37,6 +37,6 @@ export interface VersionRequest {
 }
 
 export interface VersionResponse {
-  id?: string;
+  id: string;
   doc_public_url?: string;
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -78,7 +78,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
       case 201:
         const version: VersionResponse = response.data
           ? response.data
-          : { doc_public_url: 'https://bump.sh' };
+          : { id: '', doc_public_url: 'https://bump.sh' };
 
         cli.styledSuccess(
           `Your new documentation version will soon be ready at ${version.doc_public_url}`,


### PR DESCRIPTION
This change tells the TS compiler that the Bump API will always answer with an `id` field in the responses for both POST /versions & POST /previews.

It doesn't change anything feature wise but will avoid useless JS guards when using those fields.