### PR TITLE
module: export commands and types to be able to reuse parts of the CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { run } from '@oclif/command';
+import { run } from '@oclif/command';
+import Deploy from './commands/deploy';
+import Preview from './commands/preview';
+
+export { run, Deploy, Preview };


### PR DESCRIPTION
This is some boilerplate code to be able to expose part of the CLI codebase in the NPM package.

For now we were only exporting a binary (the `bump` executable) and the `run` function from oclif if the NPM package was used as a library.

With this change, we can export parts of the CLI codebase in other packages (most importantly for us, in our `github-action` codebase). It was already possible to import parts of the `bump-cli` package by directly importing the full file path of each file (as we [did here for example](https://github.com/bump-sh/github-action/blob/master/src/main.ts#L2)) but it wasn't very satisfactory.

From now on, we can be clear with our intention and export the classes / functions / types that can be reused in other apps/libs.