### PR TITLE
readme: update the link to the Github Action diff usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please check `bump deploy --help` for more usage details
 
 ### `bump diff [FILE]`
 
-_If you want to receive automatic `bump diff` results on your Github Pull Requests you might be interested by [our Github Action](https://github.com/marketplace/actions/api-documentation-on-bump#diff) diff command._
+_If you want to receive automatic `bump diff` results on your Github Pull Requests you might be interested by [our Github Action](https://github.com/marketplace/actions/api-documentation-on-bump#api-diff-on-pull-requests) diff command._
 
 From a Bump documentation, the `diff` command will retrieve a comparaison changelog between your existing documentation and the given file or URL:
 


### PR DESCRIPTION
Following the changes of the readme on the github-action in
https://github.com/bump-sh/github-action/pull/50 we link to the
correct paragraph from the CLI readme.