### PR TITLE
feat(parser): allow markdown files to be parsed as external refs

### DIFF
--- a/examples/valid/asyncapi.v2.yml
+++ b/examples/valid/asyncapi.v2.yml
@@ -2,14 +2,8 @@ asyncapi: '2.0.0'
 info:
   title: Streetlights API
   version: '1.0.0'
-  description: |
-    The Smartylighting Streetlights API allows you to remotely manage the city lights.
-
-    ### Check out its awesome features:
-
-    * Turn a specific streetlight on/off 🌃
-    * Dim a specific streetlight 😎
-    * Receive real-time information about environmental lighting conditions 📈
+  description:
+    $ref: "./doc/introduction.md"
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/examples/valid/doc/introduction.md
+++ b/examples/valid/doc/introduction.md
@@ -1,0 +1,7 @@
+The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+### Check out its awesome features:
+
+* Turn a specific streetlight on/off 🌃
+* Dim a specific streetlight 😎
+* Receive real-time information about environmental lighting conditions 📈

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -170,6 +170,7 @@ class API {
   static async loadAPI(path: string): Promise<API> {
     const JSONParser = defaults.parse.json;
     const YAMLParser = defaults.parse.yaml;
+    const TextParser = defaults.parse.text;
     // We override the default parsers from $RefParser to be able
     // to keep the raw content of the files parsed
     const withRawTextParser = (
@@ -179,7 +180,7 @@ class API {
         ...parser,
         parse: async (file: $RefParser.FileInfo): Promise<JSONSchemaWithRaw> => {
           const parsed = (await parser.parse(file)) as JSONSchema4 | JSONSchema6;
-          return { parsed, raw: defaults.parse.text.parse(file) };
+          return { parsed, raw: TextParser.parse(file) };
         },
       };
     };
@@ -189,6 +190,15 @@ class API {
         parse: {
           json: withRawTextParser(JSONParser),
           yaml: withRawTextParser(YAMLParser),
+          text: {
+            ...TextParser,
+            parse: async (file: $RefParser.FileInfo): Promise<JSONSchemaWithRaw> => {
+              const parsed = await TextParser.parse(file);
+              return { parsed, raw: parsed };
+            },
+            canParse: ['.md', '.markdown'],
+            encoding: 'utf8',
+          },
         },
         dereference: { circular: false },
       })

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -28,7 +28,7 @@ describe('API definition class', () => {
       .it('parses successfully', async () => {
         const api = await API.loadAPI('examples/valid/asyncapi.v2.yml');
         expect(api.version).to.equal('2.0.0');
-        expect(api.references.length).to.equal(4);
+        expect(api.references.length).to.equal(5);
         expect(api.references.map((ref) => ref.location)).to.include(
           'http://example.org/param-lights.json',
         );
@@ -39,6 +39,10 @@ describe('API definition class', () => {
 
         expect(api.references.map((ref) => ref.location)).to.not.include(
           './params/streetlightId.json',
+        );
+
+        expect(api.references.map((ref) => ref.location)).to.include(
+          'doc/introduction.md',
         );
       });
   });


### PR DESCRIPTION
This PR adds a simple text parser to be able to parse `.md` or
`.markdown` files used as external refs (as a `$ref` in the contract
document).

With this change, our users will be able to extract big markdown
content from their parent contract document into dedicated external
files.

E.g.

```
openapi: 3.1.0
info:
  title: This is a super cool API
  description:
    $ref: "./api-description.md"
  version: "1.0"
servers:
  ...
paths:
  ...
```