### PR TITLE
previews: add a `--live` option to be able to do live previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ bump preview https://bit.ly/asyncapi
 
 _Note: you can use the `--open` flag to open the preview URL in your browser directly._
 
-_Note2: you can use the `--live` flag to watch changes of the input `FILE`. This is very helpful when writing your api definitionn as you will see a live preview being refreshed at each file save._
+_Note2: you can use the `--live` flag to watch changes of the input `FILE`. This is very helpful when writing your api definition as you will see a live preview being refreshed at each file save._
 
 Please check `bump preview --help` for more usage details
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ $ bump preview https://bit.ly/asyncapi
 
 _Note: you can use the `--open` flag to open the preview URL in your browser directly._
 
+_Note2: you can use the `--live` flag to watch changes of the input `FILE`. This is very helpful when writing your api definitionn as you will see a live preview being refreshed at each file save._
+
 Please check `bump preview --help` for more usage details
 
 ### `bump deploy [FILE]`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",
+        "async-mutex": "^0.3.2",
         "axios": "^0.21.1",
         "cli-ux": "^5.5.1",
         "debug": "^4.3.1",
@@ -1440,6 +1441,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/axios": {
@@ -9799,6 +9808,14 @@
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
+    },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "axios": {
       "version": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.2",
+    "async-mutex": "^0.3.2",
     "axios": "^0.21.1",
     "cli-ux": "^5.5.1",
     "debug": "^4.3.1",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -48,6 +48,13 @@ class BumpApi {
     return this.client.post<PreviewResponse>('/previews', body);
   };
 
+  public putPreview = (
+    versionId: string,
+    body?: PreviewRequest,
+  ): Promise<AxiosResponse<PreviewResponse>> => {
+    return this.client.put<PreviewResponse>(`/previews/${versionId}`, body);
+  };
+
   public postVersion = (
     body: VersionRequest,
     token: string,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -4,6 +4,9 @@ import { fileArg } from '../args';
 import { cli } from '../cli';
 import { PreviewResponse, PreviewRequest } from '../api/models';
 
+import { watch } from 'fs';
+import { Mutex } from 'async-mutex';
+
 export default class Preview extends Command {
   static description = 'create a documentation preview from the given file or URL';
 
@@ -15,6 +18,9 @@ export default class Preview extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
+    live: flags.live({
+      description: 'Generate a preview each time you save the given file',
+    }),
     open: flags.open({ description: 'Open the generated preview URL in your browser' }),
   };
 
@@ -22,26 +28,74 @@ export default class Preview extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(Preview);
-    const [definition, references] = await this.prepareDefinition(args.FILE);
 
-    cli.action.start("* Let's render a preview on Bump");
+    if (flags.live) {
+      await this.waitForChanges(args.FILE, flags.open);
+    } else {
+      await this.preview(args.FILE, flags.open);
+    }
+
+    return;
+  }
+
+  async preview(
+    file: string,
+    open = false,
+    currentPreview: PreviewResponse | undefined = undefined,
+  ): Promise<PreviewResponse> {
+    const [definition, references] = await this.prepareDefinition(file);
+
+    if (!currentPreview) {
+      cli.action.start("* Let's render a preview on Bump");
+    }
 
     const request: PreviewRequest = {
       definition,
       references,
     };
-    const response: { data: PreviewResponse } = await this.bump.postPreview(request);
+    const response: { data: PreviewResponse } = currentPreview
+      ? await this.bump.putPreview(currentPreview.id, request)
+      : await this.bump.postPreview(request);
 
-    cli.action.stop();
+    if (!currentPreview) {
+      cli.action.stop();
+      cli.styledSuccess(
+        `Your preview is visible at: ${response.data.public_url} (Expires at ${response.data.expires_at})`,
+      );
+    }
 
-    cli.styledSuccess(
-      `Your preview is visible at: ${response.data.public_url} (Expires at ${response.data.expires_at})`,
-    );
-
-    if (flags.open && response.data.public_url) {
+    if (open && response.data.public_url) {
       await cli.open(response.data.public_url);
     }
 
-    return;
+    return response.data;
+  }
+
+  async waitForChanges(file: string, open: boolean): Promise<void> {
+    const mutex = new Mutex();
+    let currentPreview: PreviewResponse | undefined = undefined;
+
+    cli.action.start(`Waiting for changes on file ${file}...`);
+
+    watch(file, async () => {
+      if (!mutex.isLocked()) {
+        const release = await mutex.acquire();
+        const firstOpen = !currentPreview && open;
+
+        this.preview(file, firstOpen, currentPreview)
+          .then((preview) => {
+            currentPreview = currentPreview || preview;
+            cli.action.start(`Waiting for changes on file ${file}`);
+          })
+          .catch((err) => {
+            this.warn(err);
+          })
+          .finally(() => {
+            setTimeout(() => {
+              release();
+            }, 1000); // Prevent previewing faster than once per second
+          });
+      }
+    });
   }
 }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -69,4 +69,12 @@ const open = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
   });
 };
 
-export { doc, docName, hub, token, autoCreate, dryRun, open };
+const live = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
+  return flags.boolean({
+    char: 'l',
+    default: false,
+    ...options,
+  });
+};
+
+export { doc, docName, hub, token, autoCreate, dryRun, open, live };


### PR DESCRIPTION
This feature adds a new flag `--live` to the `bump preview` command,
to continously update a preview at each file save.

It's very helpful when you are writing your API definition file and
want to see the result each time you save your file.

![Peek 10-09-2021 00-40](https://user-images.githubusercontent.com/904193/132820548-0292b0be-9a4d-4637-9d61-f7c5eb1932c3.gif)


_Note: This PR depends on the backend changes in bump-sh/bump#1026_