### PR TITLE
api: update Version response to include breaking information

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -42,4 +42,5 @@ export interface VersionResponse {
   doc_public_url?: string;
   diff_public_url?: string;
   diff_summary?: string;
+  diff_breaking?: boolean;
 }


### PR DESCRIPTION
This new attribute was introduced in the API here
https://developers.bump.sh/changes/a71bf771-693f-49b1-95b3-756b67e9d7bf#get-versions-parameter-200-diff_breaking