### PR TITLE
fix: yet another bugfix for the diff feature the diff is empty

### DIFF
--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -87,9 +87,9 @@ export default class Diff extends Command {
         hub,
         version && version.id,
       );
+    } else {
+      diffVersion = version;
     }
-
-    diffVersion = diffVersion || version;
 
     if (diffVersion) {
       diffVersion = await this.waitChangesResult(diffVersion.id, token, {

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -108,6 +108,33 @@ describe('diff subcommand', () => {
         api
           .post('/api/v1/versions')
           .once()
+          .reply(201, { id: '321', doc_public_url: 'http://localhost/doc/1' })
+          .post('/api/v1/versions')
+          .once()
+          .reply(204);
+      })
+      .stdout()
+      .stderr()
+      .command([
+        'diff',
+        'examples/valid/openapi.v3.json',
+        'examples/valid/openapi.v2.json',
+        '--doc',
+        'coucou',
+      ])
+      .it(
+        "doesn't display any diff when second file has no changes",
+        async ({ stdout, stderr }) => {
+          expect(stderr).to.match(/Let's compare the two given definition files/);
+          expect(stdout).to.not.contain('Updated: POST /versions');
+        },
+      );
+
+    test
+      .nock('https://bump.sh', (api) => {
+        api
+          .post('/api/v1/versions')
+          .once()
           .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
           .get('/api/v1/versions/123')
           .once()


### PR DESCRIPTION
This bug happens currently when the diff is empty AND if the first
file version has a change with the currently deployed documentation on
bump.

When a second file is provided to the CLI we should only check the
returned result of that second version, not the result of the first
version.