### PR TITLE
refacto: extract the diff logic into a dedicated class

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,18 +1,12 @@
 import { Command as Base } from '@oclif/command';
 import debug from 'debug';
 
-import { API } from './definition';
 import { BumpApi, APIError } from './api';
-import { Reference } from './api/models';
 import pjson from '../package.json';
 
 export default abstract class Command extends Base {
   private base = `${pjson.name}@${pjson.version}`;
   _bump!: BumpApi;
-
-  get pollingPeriod(): number {
-    return 1000;
-  }
 
   get bump(): BumpApi {
     if (!this._bump) this._bump = new BumpApi(this.config);
@@ -35,30 +29,5 @@ export default abstract class Command extends Base {
       formatter,
       ...args,
     );
-  }
-
-  async pollingDelay(): Promise<void> {
-    return await this.delay(this.pollingPeriod);
-  }
-
-  private async delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  async prepareDefinition(filepath: string): Promise<[string, Reference[]]> {
-    const api = await API.loadAPI(filepath);
-    const references = [];
-
-    this.d(`${filepath} looks like an ${api.specName} spec version ${api.version}`);
-
-    for (let i = 0; i < api.references.length; i++) {
-      const reference = api.references[i];
-      references.push({
-        location: reference.location,
-        content: reference.content,
-      });
-    }
-
-    return [api.rawDefinition, references];
   }
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,3 +1,4 @@
+import { API } from '../definition';
 import Command from '../command';
 import * as flags from '../flags';
 import { fileArg } from '../args';
@@ -49,11 +50,13 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
   */
   async run(): Promise<void> {
     const { args, flags } = this.parse(Deploy);
-    const [definition, references] = await this.prepareDefinition(args.FILE);
+    const api = await API.load(args.FILE);
+    const [definition, references] = api.extractDefinition();
     const action = flags['dry-run'] ? 'validate' : 'deploy';
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const [documentation, token] = [flags.doc!, flags.token!];
 
+    this.d(`${args.FILE} looks like an ${api.specName} spec version ${api.version}`);
     cli.action.start(`* Let's ${action} a new documentation version on Bump`);
 
     const request: VersionRequest = {

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,3 +1,4 @@
+import { API } from '../definition';
 import Command from '../command';
 import * as flags from '../flags';
 import { fileArg } from '../args';
@@ -43,7 +44,10 @@ export default class Preview extends Command {
     open = false,
     currentPreview: PreviewResponse | undefined = undefined,
   ): Promise<PreviewResponse> {
-    const [definition, references] = await this.prepareDefinition(file);
+    const api = await API.load(file);
+    const [definition, references] = api.extractDefinition();
+
+    this.d(`${file} looks like an ${api.specName} spec version ${api.version}`);
 
     if (!currentPreview) {
       cli.action.start("* Let's render a preview on Bump");

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,0 +1,141 @@
+import { CLIError } from '@oclif/errors';
+import * as Config from '@oclif/config';
+import debug from 'debug';
+
+import { API } from '../definition';
+import { BumpApi } from '../api';
+import { VersionRequest, VersionResponse } from '../api/models';
+
+export class Diff {
+  _bump!: BumpApi;
+  _config: Config.IConfig;
+
+  public constructor(config: Config.IConfig) {
+    this._config = config;
+  }
+
+  public async run(
+    file1: string,
+    file2: string | undefined,
+    documentation: string,
+    hub: string | undefined,
+    token: string,
+  ): Promise<VersionResponse | undefined> {
+    const version: VersionResponse | undefined = await this.createVersion(
+      file1,
+      documentation,
+      token,
+      hub,
+    );
+    let diffVersion: VersionResponse | undefined = undefined;
+
+    if (file2) {
+      diffVersion = await this.createVersion(
+        file2,
+        documentation,
+        token,
+        hub,
+        version && version.id,
+      );
+    } else {
+      diffVersion = version;
+    }
+
+    if (diffVersion) {
+      diffVersion = await this.waitResult(diffVersion.id, token, {
+        timeout: 30,
+      });
+    }
+
+    return diffVersion;
+  }
+
+  get bumpClient(): BumpApi {
+    if (!this._bump) this._bump = new BumpApi(this._config);
+    return this._bump;
+  }
+
+  get pollingPeriod(): number {
+    return 1000;
+  }
+
+  async createVersion(
+    file: string,
+    documentation: string,
+    token: string,
+    hub: string | undefined,
+    previous_version_id: string | undefined = undefined,
+  ): Promise<VersionResponse | undefined> {
+    const api = await API.load(file);
+    const [definition, references] = api.extractDefinition();
+    const request: VersionRequest = {
+      documentation,
+      hub,
+      definition,
+      references,
+      unpublished: true,
+      previous_version_id,
+    };
+
+    const response = await this.bumpClient.postVersion(request, token);
+
+    switch (response.status) {
+      case 201:
+        this.d(`Unpublished version created with ID ${response.data.id}`);
+        return response.data;
+        break;
+      case 204:
+        break;
+    }
+
+    return;
+  }
+
+  async waitResult(
+    versionId: string,
+    token: string,
+    opts: { timeout: number },
+  ): Promise<VersionResponse> {
+    const diffResponse = await this.bumpClient.getVersion(versionId, token);
+
+    if (opts.timeout <= 0) {
+      throw new CLIError(
+        'We were unable to compute your documentation diff. Sorry about that. Please try again later',
+      );
+    }
+
+    switch (diffResponse.status) {
+      case 200:
+        const version: VersionResponse = diffResponse.data;
+
+        this.d(`Received version:`);
+        this.d(version);
+        return version;
+        break;
+      case 202:
+        this.d('Waiting 1 sec before next pool');
+        await this.pollingDelay();
+        return await this.waitResult(versionId, token, {
+          timeout: opts.timeout - 1,
+        });
+        break;
+    }
+
+    return {} as VersionResponse;
+  }
+
+  async pollingDelay(): Promise<void> {
+    return await this.delay(this.pollingPeriod);
+  }
+
+  private async delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // Function signature type taken from @types/debug
+  // Debugger(formatter: any, ...args: any[]): void;
+  /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any */
+  d(formatter: any, ...args: any[]): void {
+    return debug(`bump-cli:core:diff`)(formatter, ...args);
+  }
+}

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -169,7 +169,21 @@ class API {
     return 'asyncapi' in definition;
   }
 
-  static async loadAPI(path: string): Promise<API> {
+  public extractDefinition(): [string, APIReference[]] {
+    const references = [];
+
+    for (let i = 0; i < this.references.length; i++) {
+      const reference = this.references[i];
+      references.push({
+        location: reference.location,
+        content: reference.content,
+      });
+    }
+
+    return [this.rawDefinition, references];
+  }
+
+  static async load(path: string): Promise<API> {
     const JSONParser = defaults.parse.json;
     const YAMLParser = defaults.parse.yaml;
     const TextParser = defaults.parse.text;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { run } from '@oclif/command';
-import Diff from './commands/diff';
+import { Diff } from './core/diff';
 import Deploy from './commands/deploy';
 import Preview from './commands/preview';
 import { VersionResponse } from './api/models';

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -16,8 +16,7 @@ describe('deploy subcommand', () => {
       .stdout()
       .stderr()
       .command(['deploy', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
-      .it('sends new version to Bump', ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's deploy a new documentation version/);
+      .it('sends new version to Bump', ({ stdout }) => {
         expect(stdout).to.contain(
           'Your new documentation version will soon be ready at http://localhost/doc/1',
         );

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -4,7 +4,7 @@ import { API } from '../../src/definition';
 describe('API definition class', () => {
   describe('with inexistent file', () => {
     test
-      .do(async () => await API.loadAPI('FILE'))
+      .do(async () => await API.load('FILE'))
       .catch(
         (err) => {
           expect(err.message).to.match(/Error opening file/);
@@ -16,7 +16,7 @@ describe('API definition class', () => {
 
   describe('with no references', () => {
     test.it('parses successfully', async () => {
-      const api = await API.loadAPI('examples/valid/openapi.v2.json');
+      const api = await API.load('examples/valid/openapi.v2.json');
       expect(api.version).to.equal('2.0');
       expect(api.references).to.be.an('array').that.is.empty;
     });
@@ -26,7 +26,7 @@ describe('API definition class', () => {
     test
       .nock('http://example.org', (api) => api.get('/param-lights.json').reply(200, {}))
       .it('parses successfully', async () => {
-        const api = await API.loadAPI('examples/valid/asyncapi.v2.yml');
+        const api = await API.load('examples/valid/asyncapi.v2.yml');
         expect(api.version).to.equal('2.2.0');
         expect(api.references.length).to.equal(5);
         expect(api.references.map((ref) => ref.location)).to.include(
@@ -49,14 +49,14 @@ describe('API definition class', () => {
 
   describe('with a relative descendant file path', () => {
     test.it('parses successfully', async () => {
-      const api = await API.loadAPI('./examples/valid/openapi.v2.json');
+      const api = await API.load('./examples/valid/openapi.v2.json');
       expect(api.version).to.equal('2.0');
     });
   });
 
   describe('with a file path containing special characters', () => {
     test.it('parses successfully', async () => {
-      const api = await API.loadAPI('./examples/valid/__gitlab-é__.yml');
+      const api = await API.load('./examples/valid/__gitlab-é__.yml');
       expect(api.version).to.equal('3.0.0');
     });
   });
@@ -75,7 +75,7 @@ describe('API definition class', () => {
           }),
       )
       .it('parses external file successfully', async () => {
-        const api = await API.loadAPI('http://example.org/openapi');
+        const api = await API.load('http://example.org/openapi');
         expect(api.version).to.equal('3.0.2');
         expect(api.references.map((ref) => ref.location)).to.contain('schemas/all.yml');
       });
@@ -89,7 +89,7 @@ describe('API definition class', () => {
       './examples/valid/asyncapi.v3.yml': 'Unsupported API specification',
     })) {
       test
-        .do(async () => await API.loadAPI(example))
+        .do(async () => await API.load(example))
         .catch(
           (err) => {
             expect(err.message).to.match(new RegExp(error));


### PR DESCRIPTION
This refactoring is done to extract command logic into dedicated
classes so they can be reused programmatically without the need use
the CLI commands (which is codesmell to do so cf
https://oclif.io/docs/running_programmatically ).

This will help to re-use the CLI logic inside our Github-Action
instead of relying on the oclif commands return content (which should
not be used).