### PR TITLE
diff: send 2 files diff to the new public diff endpoint

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,8 @@ import {
   PreviewResponse,
   VersionRequest,
   VersionResponse,
+  DiffRequest,
+  DiffResponse,
   WithDiff,
 } from './models';
 import { vars } from './vars';
@@ -63,6 +65,14 @@ class BumpApi {
     return this.client.post<VersionResponse>('/versions', body, {
       headers: this.authorizationHeader(token),
     });
+  };
+
+  public postDiff = (body: DiffRequest): Promise<AxiosResponse<DiffResponse>> => {
+    return this.client.post<PreviewResponse>('/diffs', body);
+  };
+
+  public getDiff = (diffId: string): Promise<AxiosResponse<DiffResponse>> => {
+    return this.client.get<DiffResponse>(`/diffs/${diffId}`);
   };
 
   public postValidation = (

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -51,6 +51,22 @@ export interface WithDiff {
   diff_breaking?: boolean;
 }
 
+export interface DiffRequest {
+  definition: string;
+  references?: Reference[];
+  previous_definition: string;
+  previous_references?: Reference[];
+}
+
+export interface DiffResponse {
+  id: string;
+  public_url?: string;
+  text?: string;
+  markdown?: string;
+  details?: DiffItem[];
+  breaking?: boolean;
+}
+
 export interface DiffItem {
   id: string;
   name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { run } from '@oclif/command';
 import { Diff } from './core/diff';
 import Deploy from './commands/deploy';
 import Preview from './commands/preview';
-import { VersionResponse, WithDiff } from './api/models';
 
-export { run, Deploy, Diff, Preview, VersionResponse, WithDiff };
+export { VersionResponse, PreviewResponse, DiffResponse, WithDiff } from './api/models';
+
+export { run, Deploy, Diff, Preview };


### PR DESCRIPTION
With this change the `bump diff` command can be used without being logged-in (without `--doc` and `--token` flags).

This allows for any given user to compare **two different API definition** files.

It makes use of the new `POST /api/v1/diffs` API available on bump.sh. (cf bump-sh/bump#1541)