### PR TITLE
diff: add new '--format' flag to render text, markdown or JSON diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ From a Bump documentation, the `diff` command will retrieve a comparaison change
 
 ```sh-session
 $ bump diff path/to/your/file.yml --doc DOC_ID_OR_SLUG --token DOC_TOKEN
-* Let's compare the given definition file with the currently deployed one... done
+* Comparing the given definition file with the currently deployed one... done
 
 Updated: POST /validations
   Body attribute modified: documentation
@@ -124,7 +124,7 @@ If you want to compare two unpublished versions of your definition file, the `di
 
 ```sh-session
 $ bump diff path/to/your/file.yml path/to/your/next-file.yml --doc <doc_slug> --token <your_doc_token>
-* Let's compare the two given definition files... done
+* Comparing the two given definition files... done
 
 Updated: POST /versions
   Body attribute added: previous_version_id

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ import {
   PreviewResponse,
   VersionRequest,
   VersionResponse,
+  WithDiff,
 } from './models';
 import { vars } from './vars';
 import APIError from './error';
@@ -36,8 +37,8 @@ class BumpApi {
   public getVersion = (
     versionId: string,
     token: string,
-  ): Promise<AxiosResponse<VersionResponse>> => {
-    return this.client.get<VersionResponse>(`/versions/${versionId}`, {
+  ): Promise<AxiosResponse<VersionResponse & WithDiff>> => {
+    return this.client.get<VersionResponse & WithDiff>(`/versions/${versionId}`, {
       headers: this.authorizationHeader(token),
     });
   };

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -41,6 +41,9 @@ export interface VersionRequest {
 export interface VersionResponse {
   id: string;
   doc_public_url?: string;
+}
+
+export interface WithDiff {
   diff_public_url?: string;
   diff_summary?: string;
   diff_markdown?: string;

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -43,5 +43,16 @@ export interface VersionResponse {
   doc_public_url?: string;
   diff_public_url?: string;
   diff_summary?: string;
+  diff_markdown?: string;
+  diff_details?: DiffItem[];
   diff_breaking?: boolean;
+}
+
+export interface DiffItem {
+  id: string;
+  name: string;
+  status: string;
+  type: string;
+  breaking: boolean;
+  children: DiffItem[];
 }

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -3,7 +3,7 @@ import * as flags from '../flags';
 import { Diff as CoreDiff } from '../core/diff';
 import { fileArg, otherFileArg } from '../args';
 import { cli } from '../cli';
-import { VersionResponse } from '../api/models';
+import { WithDiff } from '../api/models';
 
 export default class Diff extends Command {
   static description =
@@ -58,7 +58,7 @@ export default class Diff extends Command {
     the non-null assertion '!' in this command.
     See https://github.com/oclif/oclif/issues/301 for details
   */
-  async run(): Promise<VersionResponse | void> {
+  async run(): Promise<WithDiff | void> {
     const { args, flags } = this.parse(Diff);
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const [documentation, hub, token] = [flags.doc!, flags.hub, flags.token!];
@@ -73,7 +73,7 @@ export default class Diff extends Command {
       }
     }
 
-    const version: VersionResponse | undefined = await new CoreDiff(this.config).run(
+    const diff: WithDiff | undefined = await new CoreDiff(this.config).run(
       args.FILE,
       args.FILE2,
       documentation,
@@ -83,11 +83,11 @@ export default class Diff extends Command {
 
     cli.action.stop();
 
-    if (version) {
+    if (diff) {
       /* Flags format has a default value, so it's always defined. But
        * oclif types can"t detect it */
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-      await this.displayCompareResult(version, flags.format!, flags.open);
+      await this.displayCompareResult(diff, flags.format!, flags.open);
     } else {
       await cli.log('No changes detected.');
     }
@@ -96,22 +96,22 @@ export default class Diff extends Command {
   }
 
   async displayCompareResult(
-    version: VersionResponse,
+    result: WithDiff,
     format: string,
     open: boolean,
   ): Promise<void> {
-    if (format == 'text' && version && version.diff_summary) {
-      await cli.log(version.diff_summary);
-    } else if (format == 'markdown' && version && version.diff_markdown) {
-      await cli.log(version.diff_markdown);
-    } else if (format == 'json' && version && version.diff_details) {
-      await cli.log(JSON.stringify(version.diff_details, null, 2));
+    if (format == 'text' && result.diff_summary) {
+      await cli.log(result.diff_summary);
+    } else if (format == 'markdown' && result.diff_markdown) {
+      await cli.log(result.diff_markdown);
+    } else if (format == 'json' && result.diff_details) {
+      await cli.log(JSON.stringify(result.diff_details, null, 2));
     } else {
       await cli.log('No structural changes detected.');
     }
 
-    if (open && version && version.diff_public_url) {
-      await cli.open(version.diff_public_url);
+    if (open && result.diff_public_url) {
+      await cli.open(result.diff_public_url);
     }
   }
 }

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -58,7 +58,7 @@ export default class Diff extends Command {
     the non-null assertion '!' in this command.
     See https://github.com/oclif/oclif/issues/301 for details
   */
-  async run(): Promise<WithDiff | void> {
+  async run(): Promise<void> {
     const { args, flags } = this.parse(Diff);
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const [documentation, hub, token] = [flags.doc!, flags.hub, flags.token!];

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -13,14 +13,14 @@ export default class Diff extends Command {
     `Compare a potential new version with the currently published one:
 
   $ bump diff FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
-  * Let's compare the given definition file with the currently deployed one... done
+  * Comparing the given definition file with the currently deployed one... done
   Removed: GET /compare
   Added: GET /versions/{versionId}
 `,
     `Store the diff in a dedicated file:
 
   $ bump diff FILE --doc <doc_slug> --token <doc_token> > /tmp/my-saved-diff
-  * Let's compare the given definition file with the currently deployed one... done
+  * Comparing the given definition file with the currently deployed one... done
 
   $ cat /tmp/my-saved-diff
   Removed: GET /compare
@@ -29,13 +29,13 @@ export default class Diff extends Command {
     `In case of a non modified definition FILE compared to your existing documentation, no changes are output:
 
   $ bump diff FILE --doc <doc_slug> --token <your_doc_token>
-  * Let's compare the given definition file with the currently deployed one... done
+  * Comparing the given definition file with the currently deployed one... done
    ›   Warning: Your documentation has not changed
 `,
     `Compare two different input files or URL independently to the one published on bump.sh
 
   $ bump diff FILE FILE2 --doc <doc_slug> --token <your_doc_token>
-  * Let's compare the two given definition files... done
+  * Comparing the two given definition files... done
   Updated: POST /versions
     Body attribute added: previous_version_id
 `,
@@ -65,10 +65,10 @@ export default class Diff extends Command {
 
     if (flags.format == 'text') {
       if (args.FILE2) {
-        cli.action.start("* Let's compare the two given definition files");
+        cli.action.start('* Comparing the two given definition files');
       } else {
         cli.action.start(
-          "* Let's compare the given definition file with the currently deployed one",
+          '* Comparing the given definition file with the currently deployed one',
         );
       }
     }

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -4,7 +4,7 @@ import debug from 'debug';
 
 import { API } from '../definition';
 import { BumpApi } from '../api';
-import { VersionRequest, VersionResponse } from '../api/models';
+import { VersionRequest, VersionResponse, WithDiff } from '../api/models';
 
 export class Diff {
   _bump!: BumpApi;
@@ -20,7 +20,7 @@ export class Diff {
     documentation: string,
     hub: string | undefined,
     token: string,
-  ): Promise<VersionResponse | undefined> {
+  ): Promise<WithDiff | undefined> {
     const version: VersionResponse | undefined = await this.createVersion(
       file1,
       documentation,
@@ -42,12 +42,12 @@ export class Diff {
     }
 
     if (diffVersion) {
-      diffVersion = await this.waitResult(diffVersion.id, token, {
+      return await this.waitResult(diffVersion, token, {
         timeout: 30,
       });
+    } else {
+      return undefined;
     }
-
-    return diffVersion;
   }
 
   get bumpClient(): BumpApi {
@@ -92,11 +92,11 @@ export class Diff {
   }
 
   async waitResult(
-    versionId: string,
+    result: VersionResponse,
     token: string,
     opts: { timeout: number },
-  ): Promise<VersionResponse> {
-    const diffResponse = await this.bumpClient.getVersion(versionId, token);
+  ): Promise<WithDiff> {
+    const diffResponse = await this.bumpClient.getVersion(result.id, token);
 
     if (opts.timeout <= 0) {
       throw new CLIError(
@@ -106,22 +106,22 @@ export class Diff {
 
     switch (diffResponse.status) {
       case 200:
-        const version: VersionResponse = diffResponse.data;
+        const diff: WithDiff = diffResponse.data;
 
-        this.d(`Received version:`);
-        this.d(version);
-        return version;
+        this.d(`Received diff:`);
+        this.d(diff);
+        return diff;
         break;
       case 202:
         this.d('Waiting 1 sec before next pool');
         await this.pollingDelay();
-        return await this.waitResult(versionId, token, {
+        return await this.waitResult(result, token, {
           timeout: opts.timeout - 1,
         });
         break;
     }
 
-    return {} as VersionResponse;
+    return {} as WithDiff;
   }
 
   async pollingDelay(): Promise<void> {

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -108,12 +108,12 @@ export class Diff {
       case 200:
         const diff: WithDiff = diffResponse.data;
 
-        this.d(`Received diff:`);
+        this.d('Received diff:');
         this.d(diff);
         return diff;
         break;
       case 202:
-        this.d('Waiting 1 sec before next pool');
+        this.d('Waiting 1 sec before next poll');
         await this.pollingDelay();
         return await this.waitResult(result, token, {
           timeout: opts.timeout - 1,

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -77,4 +77,11 @@ const live = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
   });
 };
 
-export { doc, docName, hub, token, autoCreate, dryRun, open, live };
+const format = flags.build({
+  char: 'f',
+  description: 'Format in which to provide the diff result',
+  default: 'text',
+  options: ['text', 'markdown', 'json'],
+});
+
+export { doc, docName, hub, token, autoCreate, dryRun, open, live, format };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import { run } from '@oclif/command';
 import { Diff } from './core/diff';
 import Deploy from './commands/deploy';
 import Preview from './commands/preview';
-import { VersionResponse } from './api/models';
+import { VersionResponse, WithDiff } from './api/models';
 
-export { run, Deploy, Diff, Preview, VersionResponse };
+export { run, Deploy, Diff, Preview, VersionResponse, WithDiff };

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -38,7 +38,7 @@ describe('diff subcommand', () => {
       .it(
         'asks for a diff to Bump and returns the newly created version',
         async ({ stdout, stderr }) => {
-          expect(stderr).to.match(/Let's compare the given definition file/);
+          expect(stderr).to.match(/Comparing the given definition file/);
           expect(stdout).to.contain('Updated: POST /versions');
         },
       );
@@ -69,7 +69,7 @@ describe('diff subcommand', () => {
         'coucou',
       ])
       .it('asks for a diff between the two files to Bump', async ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's compare the two given definition files/);
+        expect(stderr).to.match(/Comparing the two given definition files/);
         expect(stdout).to.contain('Updated: POST /versions');
       });
 
@@ -101,7 +101,7 @@ describe('diff subcommand', () => {
       .it(
         'asks for a diff between the two files to Bump even when first file has no changes compared to currently deployed version',
         async ({ stdout, stderr }) => {
-          expect(stderr).to.match(/Let's compare the two given definition files/);
+          expect(stderr).to.match(/Comparing the two given definition files/);
           expect(stdout).to.contain('Updated: POST /versions');
         },
       );
@@ -128,7 +128,7 @@ describe('diff subcommand', () => {
       .it(
         "doesn't display any diff when second file has no changes",
         async ({ stdout, stderr }) => {
-          expect(stderr).to.match(/Let's compare the two given definition files/);
+          expect(stderr).to.match(/Comparing the two given definition files/);
           expect(stdout).to.not.contain('Updated: POST /versions');
         },
       );
@@ -147,7 +147,7 @@ describe('diff subcommand', () => {
       .stderr()
       .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
       .it('asks for a diff with content change only', async ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's compare the given definition file/);
+        expect(stderr).to.match(/Comparing the given definition file/);
         expect(stdout).to.contain('No structural changes detected.');
       });
 
@@ -159,7 +159,7 @@ describe('diff subcommand', () => {
       .stderr()
       .command(['diff', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
       .it('notifies an unchanged definition', async ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's compare the given definition file/);
+        expect(stderr).to.match(/Comparing the given definition file/);
         expect(stdout).to.contain('No changes detected.');
       });
   });
@@ -217,7 +217,7 @@ describe('diff subcommand', () => {
         })
         .exit(2)
         .it('asks for a diff to Bump', async ({ stdout, stderr }) => {
-          expect(stderr).to.match(/Let's compare the given definition file/);
+          expect(stderr).to.match(/Comparing the given definition file/);
           expect(stdout).to.eq('');
         });
     });


### PR DESCRIPTION
This commit adds a new `--format` flag to the `bump diff` command to
return the diff result in either:
- `text` format (this is the default and current behavior)
- `markdown` format. Renders a markdown formatted text
- `json` format. Renders a json object with all the diff details.

_Bonus: the PR also contains a small refactoring of types to handle
diffs in an easier fashion (Will be helpful for our “Bump diff v2” cf
#221)_