### PR TITLE
tests: fix stubbing of core diff polling period

### DIFF
--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -1,7 +1,7 @@
 import base, { expect } from '@oclif/test';
 import nock from 'nock';
 import * as sinon from 'sinon';
-import { Diff } from '../../src/core/diff';
+import { Diff } from '../../lib/core/diff';
 
 nock.disableNetConnect();
 


### PR DESCRIPTION
Since #192, the polling period was not stubbed in the diffs tests
anymore (and thus taking 32s of waiting during tests for nothing...).

I didn't really understand why but I needed to import the core diff
from the `lib/` dir instead of the `src/` dir. 🤷