### PR TITLE
tests: fixing api unit test when cli version has a tag

### DIFF
--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -70,7 +70,7 @@ describe('BumpApi HTTP client class', () => {
       .it('sends User-Agent with custom content', async () => {
         expect(matchUserAgentHeader.firstCall.args[0]).to.match(
           new RegExp(
-            `^bump-cli/([0-9\.]+) ${os.platform()}-${os.arch()} node-v[0-9\.]+ ua-extra-content$`,
+            `^bump-cli/([0-9\.]+)(-[a-z]+)? ${os.platform()}-${os.arch()} node-v[0-9\.]+ ua-extra-content$`,
           ),
         );
       });


### PR DESCRIPTION
This is a fix for the unit test testing the CLI user agent used. When
the version is published with a tag (`-beta`) the tests were failing.

With this commit we accept any tag behind the version number. 😌