### PR TITLE
diff: send format parameter to the API calls to get diff result

### DIFF
--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -33,7 +33,7 @@ export default class APIError extends CLIError {
     if (info.length) {
       super(info.join('\n'));
     } else {
-      super(`Unhandled API error (status: ${status})`);
+      super(`Unhandled API error (status: ${status}) (error: ${httpError})`);
     }
 
     this.exitCode = exit;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -71,8 +71,13 @@ class BumpApi {
     return this.client.post<PreviewResponse>('/diffs', body);
   };
 
-  public getDiff = (diffId: string): Promise<AxiosResponse<DiffResponse>> => {
-    return this.client.get<DiffResponse>(`/diffs/${diffId}`);
+  public getDiff = (
+    diffId: string,
+    format: string,
+  ): Promise<AxiosResponse<DiffResponse>> => {
+    return this.client.get<DiffResponse>(`/diffs/${diffId}`, {
+      params: { formats: [format] },
+    });
   };
 
   public postValidation = (

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -61,10 +61,11 @@ export interface DiffRequest {
 export interface DiffResponse {
   id: string;
   public_url?: string;
+  breaking?: boolean;
   text?: string;
   markdown?: string;
   details?: DiffItem[];
-  breaking?: boolean;
+  html?: string;
 }
 
 export interface DiffItem {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -62,9 +62,17 @@ export default class Diff extends Command {
   */
   async run(): Promise<void> {
     const { args, flags } = this.parse(Diff);
-    const [documentation, hub, token] = [flags.doc, flags.hub, flags.token];
+    /* Flags.format has a default value, so it's always defined. But
+     * oclif types doesn't detect it */
+    const [documentation, hub, token, format] = [
+      flags.doc,
+      flags.hub,
+      flags.token,
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      flags.format!,
+    ];
 
-    if (flags.format == 'text') {
+    if (format === 'text') {
       if (args.FILE2) {
         cli.action.start('* Comparing the two given definition files');
       } else {
@@ -86,15 +94,13 @@ export default class Diff extends Command {
       documentation,
       hub,
       token,
+      format,
     );
 
     cli.action.stop();
 
     if (diff) {
-      /* Flags format has a default value, so it's always defined. But
-       * oclif types can"t detect it */
-      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-      await this.displayCompareResult(diff, flags.format!, flags.open);
+      await this.displayCompareResult(diff, format, flags.open);
     } else {
       await cli.log('No changes detected.');
     }
@@ -113,6 +119,8 @@ export default class Diff extends Command {
       await cli.log(result.markdown);
     } else if (format == 'json' && result.details) {
       await cli.log(JSON.stringify(result.details, null, 2));
+    } else if (format == 'html' && result.html) {
+      await cli.log(result.html);
     } else {
       await cli.log('No structural changes detected.');
     }

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -26,6 +26,7 @@ export class Diff {
     documentation: string | undefined,
     hub: string | undefined,
     token: string | undefined,
+    format: string,
   ): Promise<DiffResponse | undefined> {
     let diffVersion: VersionResponse | DiffResponse | undefined = undefined;
 
@@ -54,6 +55,7 @@ export class Diff {
     if (diffVersion) {
       return await this.waitResult(diffVersion, token, {
         timeout: 30,
+        format,
       });
     } else {
       return undefined;
@@ -131,14 +133,14 @@ export class Diff {
   async waitResult(
     result: VersionResponse | DiffResponse,
     token: string | undefined,
-    opts: { timeout: number },
+    opts: { timeout: number; format: string },
   ): Promise<DiffResponse> {
     let pollingResponse = undefined;
 
     if (this.isVersion(result) && token) {
       pollingResponse = await this.bumpClient.getVersion(result.id, token);
     } else {
-      pollingResponse = await this.bumpClient.getDiff(result.id);
+      pollingResponse = await this.bumpClient.getDiff(result.id, opts.format);
     }
 
     if (opts.timeout <= 0) {
@@ -164,6 +166,7 @@ export class Diff {
         await this.pollingDelay();
         return await this.waitResult(result, token, {
           timeout: opts.timeout - 1,
+          format: opts.format,
         });
         break;
     }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -81,7 +81,7 @@ const format = flags.build({
   char: 'f',
   description: 'Format in which to provide the diff result',
   default: 'text',
-  options: ['text', 'markdown', 'json'],
+  options: ['text', 'markdown', 'json', 'html'],
 });
 
 export { doc, docName, hub, token, autoCreate, dryRun, open, live, format };

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -142,10 +142,10 @@ describe('diff subcommand', () => {
             id: '321abc',
             public_url: 'http://localhost/preview/321abc',
           })
-          .get('/api/v1/diffs/321abc')
+          .get('/api/v1/diffs/321abc?formats[]=text')
           .once()
           .reply(202)
-          .get('/api/v1/diffs/321abc')
+          .get('/api/v1/diffs/321abc?formats[]=text')
           .once()
           .reply(200, { diff_summary: 'Updated: POST /versions' });
       })


### PR DESCRIPTION
Now that our API has a [`formats` parameter](https://developers.bump.sh/changes#event-change-62c8d3d6-c8b9-4146-8e95-0e0819afb9c5) let's use it to retrieve only the format asked by the CLI user.