### PR TITLE
deps: use @oclif/core instead of cli-ux npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^2.13.0",
-        "@oclif/command": "^1.8.0",
+        "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.17.0",
+        "@oclif/core": "^1.3.3",
         "@oclif/plugin-help": "^5.1.10",
         "async-mutex": "^0.3.2",
         "axios": "^0.26.0",
-        "cli-ux": "^6.0.7",
         "debug": "^4.3.1",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
         "tslib": "^2.3.0"
@@ -1179,6 +1179,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
       "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
+      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2524,111 +2525,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cli-ux": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.9.tgz",
-      "integrity": "sha512-0Ku29QLf+P6SeBNWM7zyoJ49eKKOjxZBZ4OH2aFeRtC0sNXU3ftdJxQPKJ1SJ+axX34I1NsfTFahpXdnxklZgA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@oclif/core": "^1.1.1",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4 ",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.10.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/cli-ux/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -3428,6 +3324,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
       "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10147,7 +10044,8 @@
     "@oclif/screen": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
+      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
+      "dev": true
     },
     "@oclif/test": {
       "version": "2.1.0",
@@ -11179,93 +11077,6 @@
         }
       }
     },
-    "cli-ux": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-6.0.9.tgz",
-      "integrity": "sha512-0Ku29QLf+P6SeBNWM7zyoJ49eKKOjxZBZ4OH2aFeRtC0sNXU3ftdJxQPKJ1SJ+axX34I1NsfTFahpXdnxklZgA==",
-      "requires": {
-        "@oclif/core": "^1.1.1",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4 ",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.10.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -11893,7 +11704,8 @@
     "extract-stack": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ=="
+      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
+      "dev": true
     },
     "fancy-test": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,12 +78,12 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@asyncapi/specs": "^2.13.0",
-    "@oclif/command": "^1.8.0",
+    "@oclif/command": "^1.8.16",
     "@oclif/config": "^1.17.0",
+    "@oclif/core": "^1.3.3",
     "@oclif/plugin-help": "^5.1.10",
     "async-mutex": "^0.3.2",
     "axios": "^0.26.0",
-    "cli-ux": "^6.0.7",
     "debug": "^4.3.1",
     "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#0f9d3ec7c033fef184ec54e1ffc201b2d61ce023",
     "tslib": "^2.3.0"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import cliUx from 'cli-ux';
+import { CliUx } from '@oclif/core';
 
 import success from './styled/success';
 
@@ -6,10 +6,10 @@ type Levels = 'info' | 'debug';
 
 if (process.env.BUMP_LOG_LEVEL) {
   const logLevel: string = process.env.BUMP_LOG_LEVEL;
-  cliUx.config['outputLevel'] = logLevel as Levels;
+  CliUx.config['outputLevel'] = logLevel as Levels;
 }
 const cli = {
-  ...cliUx,
+  ...CliUx.ux,
   get styledSuccess(): typeof success {
     return success;
   },


### PR DESCRIPTION
Cli-ux has been migrated to a new package @oclif/core which
incorporates all other oclif packages (@oclif/command and
@oclif/config).

We will migrate @oclif/command and @oclif/config in a later PR.

This will remove the `WARNING` message when users install `bump-cli`
warning them that we use a deprecated `cli-ux` package.