### PR TITLE
branching: adapt `deploy` & `diff` commands to accept branch input

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -36,6 +36,7 @@ export interface VersionRequest {
   references?: Reference[];
   unpublished?: boolean;
   previous_version_id?: string;
+  branch_name?: string;
 }
 
 export interface VersionResponse {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -35,6 +35,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
     doc: flags.doc(),
     'doc-name': flags.docName(),
     hub: flags.hub(),
+    branch: flags.branch(),
     token: flags.token(),
     'auto-create': flags.autoCreate(),
     'dry-run': flags.dryRun(),
@@ -66,6 +67,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
       auto_create_documentation: flags['auto-create'] && !flags['dry-run'],
       definition,
       references,
+      branch_name: flags.branch,
     };
 
     const response = flags['dry-run']

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -47,6 +47,7 @@ export default class Diff extends Command {
     help: flags.help({ char: 'h' }),
     doc: flags.doc({ required: false }),
     hub: flags.hub(),
+    branch: flags.branch(),
     token: flags.token({ required: false }),
     open: flags.open({ description: 'Open the visual diff in your browser' }),
     format: flags.format(),
@@ -64,9 +65,10 @@ export default class Diff extends Command {
     const { args, flags } = this.parse(Diff);
     /* Flags.format has a default value, so it's always defined. But
      * oclif types doesn't detect it */
-    const [documentation, hub, token, format] = [
+    const [documentation, hub, branch, token, format] = [
       flags.doc,
       flags.hub,
+      flags.branch,
       flags.token,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       flags.format!,
@@ -93,6 +95,7 @@ export default class Diff extends Command {
       args.FILE2,
       documentation,
       hub,
+      branch,
       token,
       format,
     );

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -25,6 +25,7 @@ export class Diff {
     file2: string | undefined,
     documentation: string | undefined,
     hub: string | undefined,
+    branch: string | undefined,
     token: string | undefined,
     format: string,
   ): Promise<DiffResponse | undefined> {
@@ -39,7 +40,7 @@ export class Diff {
         );
       }
 
-      diffVersion = await this.createVersion(file1, documentation, token, hub);
+      diffVersion = await this.createVersion(file1, documentation, token, hub, branch);
 
       if (file2) {
         diffVersion = await this.createVersion(
@@ -47,6 +48,7 @@ export class Diff {
           documentation,
           token,
           hub,
+          branch,
           diffVersion && diffVersion.id,
         );
       }
@@ -103,6 +105,7 @@ export class Diff {
     documentation: string,
     token: string,
     hub: string | undefined,
+    branch_name: string | undefined,
     previous_version_id: string | undefined = undefined,
   ): Promise<VersionResponse | undefined> {
     const api = await API.load(file);
@@ -114,6 +117,7 @@ export class Diff {
       references,
       unpublished: true,
       previous_version_id,
+      branch_name,
     };
 
     const response = await this.bumpClient.postVersion(request, token);

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -33,6 +33,15 @@ const hub = flags.build({
   },
 });
 
+const branch = flags.build({
+  char: 'B',
+  description: 'Branch name. Can be provided via BUMP_BRANCH_NAME environment variable',
+  default: () => {
+    const envBranch = process.env.BUMP_BRANCH_NAME;
+    if (envBranch) return envBranch;
+  },
+});
+
 const token = flags.build({
   char: 't',
   required: true,
@@ -84,4 +93,4 @@ const format = flags.build({
   options: ['text', 'markdown', 'json', 'html'],
 });
 
-export { doc, docName, hub, token, autoCreate, dryRun, open, live, format };
+export { doc, docName, hub, branch, token, autoCreate, dryRun, open, live, format };


### PR DESCRIPTION
This commit adapts both the `deploy` and `diff` commands to accept a
new CLI parameter: `-B name` (or its long version `--branch=name) to
be able to deploy (or diff) a new version on a specified branch.

By default any commands running against a documentation without branch
information will affect the “default” branch.

Closes #299