### PR TITLE
diff: add cmd argument `--wait` to customise waiting period

### DIFF
--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -51,6 +51,7 @@ export default class Diff extends Command {
     token: flags.token({ required: false }),
     open: flags.open({ description: 'Open the visual diff in your browser' }),
     format: flags.format(),
+    wait: flags.wait(),
   };
 
   static args = [fileArg, otherFileArg];
@@ -65,13 +66,15 @@ export default class Diff extends Command {
     const { args, flags } = this.parse(Diff);
     /* Flags.format has a default value, so it's always defined. But
      * oclif types doesn't detect it */
-    const [documentation, hub, branch, token, format] = [
+    const [documentation, hub, branch, token, format, wait] = [
       flags.doc,
       flags.hub,
       flags.branch,
       flags.token,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       flags.format!,
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      isNaN(parseInt(flags.wait!)) ? 60 : parseInt(flags.wait!),
     ];
 
     if (format === 'text') {
@@ -98,6 +101,7 @@ export default class Diff extends Command {
       branch,
       token,
       format,
+      wait,
     );
 
     cli.action.stop();

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -28,6 +28,7 @@ export class Diff {
     branch: string | undefined,
     token: string | undefined,
     format: string,
+    waitUntil: number,
   ): Promise<DiffResponse | undefined> {
     let diffVersion: VersionResponse | DiffResponse | undefined = undefined;
 
@@ -56,7 +57,7 @@ export class Diff {
 
     if (diffVersion) {
       return await this.waitResult(diffVersion, token, {
-        timeout: 30,
+        timeout: waitUntil,
         format,
       });
     } else {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -93,4 +93,12 @@ const format = flags.build({
   options: ['text', 'markdown', 'json', 'html'],
 });
 
-export { doc, docName, hub, branch, token, autoCreate, dryRun, open, live, format };
+const wait = flags.build({
+  char: 'w',
+  description: 'Wait up to X seconds for diff result. Defaults to 60 seconds.',
+  default: (): string => {
+    return process.env.BUMP_DIFF_WAIT || '60';
+  },
+});
+
+export { doc, docName, hub, branch, token, autoCreate, dryRun, open, live, format, wait };


### PR DESCRIPTION
On some big specs (with multiple external refs), a diff can take quite
a long time. Let's leave the possibility to increase the current default 30
seconds timeout which the CLI waits for before abandoning.