### PR TITLE
fix: send relative paths for external file system paths on Windows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # - windows-latest
+          - windows-latest
         node_version: [ '14', '16', '18' ]
         architecture: [ 'x64' ]
         # an extra windows-x86 run:
@@ -25,9 +25,9 @@ jobs:
         #     architecture: x86
     name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -36,7 +36,7 @@ jobs:
           key: ${{ matrix.os }}-node-${{ matrix.node_version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ matrix.node_version }}-build-${{ env.cache-name }}-
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -108,8 +108,9 @@ class API {
     const refUrl = url(absPath);
 
     if (
-      absPath.match(/^\//) ||
-      (absPath.match(/^https?:\/\//) && definitionUrl.hostname === refUrl.hostname)
+      absPath.match(/^\//) || // Unix style filesystem path
+      absPath.match(/^[a-zA-Z]+\:\\/) || // Windows style filesystem path
+      (absPath.match(/^https?:\/\//) && definitionUrl.hostname === refUrl.hostname) // Same domain URLs
     ) {
       return path.relative(path.dirname(this.location), absPath);
     } else {

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@oclif/test';
 import { API } from '../../src/definition';
 import nock from 'nock';
+import path from 'path';
 
 nock.disableNetConnect();
 
@@ -46,21 +47,16 @@ describe('API definition class', () => {
         const api = await API.load('examples/valid/asyncapi.v2.yml');
         expect(api.version).to.equal('2.2.0');
         expect(api.references.length).to.equal(5);
-        expect(api.references.map((ref) => ref.location)).to.include(
-          'http://example.org/param-lights.json',
+        const locations = api.references.map((ref) => ref.location);
+        expect(locations).to.include('http://example.org/param-lights.json');
+
+        expect(locations).to.include(['params', 'streetlightId.json'].join(path.sep));
+
+        expect(locations).to.not.include(
+          ['.', 'params', 'streetlightId.json'].join(path.sep),
         );
 
-        expect(api.references.map((ref) => ref.location)).to.include(
-          'params/streetlightId.json',
-        );
-
-        expect(api.references.map((ref) => ref.location)).to.not.include(
-          './params/streetlightId.json',
-        );
-
-        expect(api.references.map((ref) => ref.location)).to.include(
-          'doc/introduction.md',
-        );
+        expect(locations).to.include(['doc', 'introduction.md'].join(path.sep));
       });
   });
 
@@ -94,7 +90,9 @@ describe('API definition class', () => {
       .it('parses external file successfully', async () => {
         const api = await API.load('http://example.org/openapi');
         expect(api.version).to.equal('3.0.2');
-        expect(api.references.map((ref) => ref.location)).to.contain('schemas/all.yml');
+        expect(api.references.map((ref) => ref.location)).to.contain(
+          ['schemas', 'all.yml'].join(path.sep),
+        );
       });
   });
 


### PR DESCRIPTION
This commit is a bugfix for Windows based filesystem when external
references are defined on disk. Indeed we had a wrong regexp matchin
only unix style filesystem paths.

The fix consists of parsing windows style filesystem paths too.

I've tested it on a VM and the fix seems to work fine.