### PR TITLE
diff: add a `--expires` CLI parameter for public diffs

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -57,6 +57,7 @@ export interface DiffRequest {
   references?: Reference[];
   previous_definition: string;
   previous_references?: Reference[];
+  expires_at?: string;
 }
 
 export interface DiffResponse {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -51,6 +51,7 @@ export default class Diff extends Command {
     token: flags.token({ required: false }),
     open: flags.open({ description: 'Open the visual diff in your browser' }),
     format: flags.format(),
+    expires: flags.expires(),
   };
 
   static args = [fileArg, otherFileArg];
@@ -65,13 +66,14 @@ export default class Diff extends Command {
     const { args, flags } = this.parse(Diff);
     /* Flags.format has a default value, so it's always defined. But
      * oclif types doesn't detect it */
-    const [documentation, hub, branch, token, format] = [
+    const [documentation, hub, branch, token, format, expires] = [
       flags.doc,
       flags.hub,
       flags.branch,
       flags.token,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       flags.format!,
+      flags.expires,
     ];
 
     if (format === 'text') {
@@ -98,6 +100,7 @@ export default class Diff extends Command {
       branch,
       token,
       format,
+      expires,
     );
 
     cli.action.stop();

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -28,11 +28,12 @@ export class Diff {
     branch: string | undefined,
     token: string | undefined,
     format: string,
+    expires: string | undefined,
   ): Promise<DiffResponse | undefined> {
     let diffVersion: VersionResponse | DiffResponse | undefined = undefined;
 
     if (file2 && (!documentation || !token)) {
-      diffVersion = await this.createDiff(file1, file2);
+      diffVersion = await this.createDiff(file1, file2, expires);
     } else {
       if (!documentation || !token) {
         throw new Error(
@@ -73,7 +74,11 @@ export class Diff {
     return 1000;
   }
 
-  async createDiff(file1: string, file2: string): Promise<DiffResponse | undefined> {
+  async createDiff(
+    file1: string,
+    file2: string,
+    expires: string | undefined,
+  ): Promise<DiffResponse | undefined> {
     const api = await API.load(file1);
     const [previous_definition, previous_references] = api.extractDefinition();
     const api2 = await API.load(file2);
@@ -83,6 +88,7 @@ export class Diff {
       previous_references,
       definition,
       references,
+      expires_at: expires,
     };
 
     const response = await this.bumpClient.postDiff(request);

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -93,4 +93,22 @@ const format = flags.build({
   options: ['text', 'markdown', 'json', 'html'],
 });
 
-export { doc, docName, hub, branch, token, autoCreate, dryRun, open, live, format };
+const expires = flags.build({
+  char: 'e',
+  description:
+    "Specify a longer expiration date for public diffs (defaults to 1 day). Use iso8601 format to provide a date, or you can use `--expires 'never'` to keep the result live indefinitely.",
+});
+
+export {
+  doc,
+  docName,
+  hub,
+  branch,
+  token,
+  autoCreate,
+  dryRun,
+  open,
+  live,
+  format,
+  expires,
+};


### PR DESCRIPTION
When creating a public diff (non authenticated `bump diff` command),
users will now be able to provide an extra `--expires <date>`
parameter to change the default (1 day) expiration date of public
diffs.

Format of the date is in `iso8601`. The parameter can also receive
`never` value if the user doesn't want to publid diff to expire.