### PR TITLE
asyncapi: allow 2.6.0 version of AsyncAPI contracts

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -23,6 +23,7 @@ class SupportedFormat {
     '2.3': asyncapi['2.3.0'],
     '2.4': asyncapi['2.4.0'],
     '2.5': asyncapi['2.5.0'],
+    '2.6': asyncapi['2.6.0'],
   };
 }
 


### PR DESCRIPTION
Even if we don't fully support the new
version (https://www.asyncapi.com/blog/release-notes-2.6.0) we can
accept the new version contracts to be sent to bump.sh.