### PR TITLE
preview: send a first preview after exectution of the command

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -30,10 +30,9 @@ export default class Preview extends Command {
   async run(): Promise<void> {
     const { args, flags } = this.parse(Preview);
 
+    await this.preview(args.FILE, flags.open);
     if (flags.live) {
       await this.waitForChanges(args.FILE, flags.open);
-    } else {
-      await this.preview(args.FILE, flags.open);
     }
 
     return;


### PR DESCRIPTION
With the `preview --live` command we used to wait for some changes on
the target file before launching the preview.

With this PR we generate a first preview with the given file, THEN
wait for future changes on the file.

About #182