### PR TITLE
deploy: add hub directory deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ If you already have a hub in your [Bump.sh](https://bump.sh) account, you can au
 $ bump deploy path/to/your/file.yml --auto-create --doc DOC_SLUG --hub HUB_ID_OR_SLUG --token HUB_TOKEN
 ```
 
+Within a Hub, you can also deploy a whole directory containing multiple API definitions in a single command:
+
+```sh-session
+$ bump deploy path/to/your/apis/ --auto-create --hub HUB_ID_OR_SLUG --token HUB_TOKEN
+```
+
 Simulate a deployment of your definition file to make sure it is valid with the `--dry-run` flag, it is particularly useful in a Continuous Integration environment running a test deployment outside your main branch:
 
 ```sh-session

--- a/examples/valid/bump-api.json
+++ b/examples/valid/bump-api.json
@@ -1,0 +1,259 @@
+{
+  "components": {
+    "requestBodies": {
+      "Preview": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "definition": {
+                  "description": "Serialized definition of the version. This should be an OpenAPI 2.x, 3.x or AsyncAPI 2.x file serialized as a string, in YAML or JSON.\n",
+                  "example": "{asyncapi: \"2.0\", \"info\": { \"title: ... }}\n",
+                  "type": "string"
+                },
+                "references": {
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "items": {
+                    "$ref": "#/components/schemas/Reference"
+                  },
+                  "type": "array"
+                },
+                "specification": {
+                  "description": "Specification for the definition, as a path: `speficiation_name/specification_version/format`. Example: `openapi/v2/yaml`.",
+                  "enum": [
+                    "openapi/v2/yaml",
+                    "openapi/v2/json",
+                    "openapi/v3/yaml",
+                    "openapi/v3/json"
+                  ],
+                  "example": "openapi/v2/yaml",
+                  "type": "string"
+                },
+                "validation": {
+                  "description": "Validation strategy:\n- `basic`: basic validation (default)\n- `strict`: validate the file against its specification\n",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "definition"
+              ]
+            }
+          }
+        },
+        "description": "The version object"
+      },
+      "Version": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "auto_create_documentation": {
+                  "default": false,
+                  "description": "Create the documentation if not existing yet. Must be used with a `hub_id` or `hub_slug`, and a `documentation_slug`.",
+                  "type": "boolean"
+                },
+                "definition": {
+                  "description": "Serialized definition of the version. This should be an OpenAPI 2.x, 3.x or AsyncAPI 2.x file serialized as a string, in YAML or JSON.\n",
+                  "example": "{openapi: \"3.0\", \"info\": { \"title: ... }}\n",
+                  "type": "string"
+                },
+                "documentation_id": {
+                  "description": "UUID of the documentation. Required if `documentation_slug` is empty.",
+                  "type": "string"
+                },
+                "documentation_slug": {
+                  "description": "Slug of the documentation. Required if `documentation_id` is empty.",
+                  "type": "string"
+                },
+                "hub_id": {
+                  "description": "UUID of the hub if the documentation is part of a hub.",
+                  "type": "string"
+                },
+                "hub_slug": {
+                  "description": "Slug of the hub if the documentation is part of a hub.",
+                  "type": "string"
+                },
+                "references": {
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "items": {
+                    "$ref": "#/components/schemas/Reference"
+                  },
+                  "type": "array"
+                },
+                "specification": {
+                  "description": "Specification for the definition, as a path: `speficiation_name/specification_version/format`. Example: `openapi/v2/yaml`.",
+                  "enum": [
+                    "openapi/v2/yaml",
+                    "openapi/v2/json",
+                    "openapi/v3/yaml",
+                    "openapi/v3/json"
+                  ],
+                  "example": "openapi/v2/yaml",
+                  "type": "string"
+                },
+                "validation": {
+                  "description": "Validation strategy:\n- `basic`: basic validation (default)\n- `strict`: validate the file against its specification\n",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "definition"
+              ]
+            }
+          }
+        },
+        "description": "The version object"
+      }
+    },
+    "responses": {
+      "InvalidDefinition": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "schemas/all.yml#/Error"
+            }
+          }
+        },
+        "description": "Definition is not valid."
+      }
+    },
+    "schemas": {
+      "Pong": {
+        "properties": {
+          "pong": {
+            "description": "Sentence about ping and pong",
+            "example": "And that's how ping-pong ball is bumped",
+            "type": "string"
+          }
+        }
+      },
+      "Preview": {
+        "properties": {
+          "expires_at": {
+            "description": "Preview expiration date and time.",
+            "example": "2010-04-14T17:05:00+01:00",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique id for the preview URL: `https://bump.sh/preview/:id`.",
+            "example": "3ef8f52f-9056-4113-840e-2f7183b90e06",
+            "type": "string"
+          }
+        }
+      },
+      "Reference": {
+        "properties": {
+          "content": {
+            "description": "Content of the external reference, as a string.",
+            "type": "string"
+          },
+          "location": {
+            "description": "Location of the external reference as it's called from `definition`, without the relative path (the part after `#/`). Can be an URL of a file system path.",
+            "example": "https://example.com/api/models/pet.yml",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
+    "title": "Bump Api",
+    "version": "1.0"
+  },
+  "openapi": "3.0.2",
+  "paths": {
+    "/ping": {
+      "get": {
+        "description": "Responds a pong if the API is up and running.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pong"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "default": {
+            "description": "API is currently down"
+          }
+        },
+        "summary": "Check the API status"
+      }
+    },
+    "/previews": {
+      "post": {
+        "description": "Create a preview for a given documentation file. The preview will have a unique temporary URL, and will be active for 30 minutes.\n",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Preview"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Preview"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidDefinition"
+          }
+        },
+        "summary": "Create a preview"
+      }
+    },
+    "/validations": {
+      "post": {
+        "description": "Validate a definition against its schema (OpenAPI or AsyncAPI) and return errors without creating a new version. This is useful in a CI process, to validate that a changed definition file is valid and won't fail when being deployed on Bump.\n",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Version"
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidDefinition"
+          }
+        },
+        "summary": "Validate a documentation definition"
+      }
+    },
+    "/versions": {
+      "post": {
+        "description": "Deploy a new version for a given documentation, which will become the current version.\n",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Version"
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidDefinition"
+          }
+        },
+        "summary": "Create a new version"
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://bump.sh/api/v1"
+    }
+  ],
+  "x-topics": [
+    {
+      "content": "# Api token authentication\n\nUse the token from your documentation settings as the username of the basic auth, with no password.\n\nExample: `curl https://bump.sh/api/v1/docs/1/versions -u DOC_TOKEN:`\n\nNote that adding a colon after your token prevents cURL from asking for a password.\n",
+      "title": "Authentication"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "@asyncapi/specs": "^4.0.1",
+        "@clack/prompts": "^0.6.3",
         "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.17.0",
         "@oclif/core": "^1.3.3",
@@ -386,6 +387,40 @@
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-FZnsNynwGDIDktx6PEZK1EuCkFpY4ldEX6VYvfl0dqeoLPb9Jpw1xoUXaVcGR8ExmYNm1w2vdGdJkEUYD/2pqg==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.6.3.tgz",
+      "integrity": "sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==",
+      "bundleDependencies": [
+        "is-unicode-supported"
+      ],
+      "dependencies": {
+        "@clack/core": "^0.3.2",
+        "is-unicode-supported": "*",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -4978,7 +5013,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7591,6 +7625,11 @@
         "node": "*"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -8487,6 +8526,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -9964,6 +10008,32 @@
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@clack/core": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-FZnsNynwGDIDktx6PEZK1EuCkFpY4ldEX6VYvfl0dqeoLPb9Jpw1xoUXaVcGR8ExmYNm1w2vdGdJkEUYD/2pqg==",
+      "requires": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "@clack/prompts": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.6.3.tgz",
+      "integrity": "sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==",
+      "requires": {
+        "@clack/core": "^0.3.2",
+        "is-unicode-supported": "*",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      },
+      "dependencies": {
+        "is-unicode-supported": {
+          "version": "1.3.0",
+          "bundled": true
+        }
       }
     },
     "@cspotcode/source-map-support": {
@@ -13390,8 +13460,7 @@
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "is-url-superb": {
       "version": "4.0.0",
@@ -15364,6 +15433,11 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -16032,6 +16106,11 @@
           }
         }
       }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "@types/debug": "^4.1.5",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.18",
-        "@typescript-eslint/eslint-plugin": "^4.21.0",
-        "@typescript-eslint/parser": "^4.21.0",
+        "@typescript-eslint/eslint-plugin": "^5.21.0",
+        "@typescript-eslint/parser": "^5.21.0",
         "chai": "^4.3.4",
         "cross-spawn": "^7.0.3",
         "eslint": "^7.24.0",
@@ -46,7 +46,7 @@
         "sinon": "^14.0.0",
         "stdout-stderr": "^0.1.13",
         "ts-node": "^10.0.0",
-        "typescript": "^4.3.3"
+        "typescript": "^4.5.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -398,6 +398,42 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1479,6 +1515,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
@@ -1489,30 +1531,32 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.6.tgz",
+      "integrity": "sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/type-utils": "5.59.6",
+        "@typescript-eslint/utils": "5.59.6",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1520,77 +1564,72 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "dev": true,
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.6.tgz",
+      "integrity": "sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.6.tgz",
+      "integrity": "sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/visitor-keys": "5.59.6"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.6.tgz",
+      "integrity": "sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "@typescript-eslint/utils": "5.59.6",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1598,54 +1637,42 @@
       },
       "peerDependencies": {
         "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.6.tgz",
+      "integrity": "sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==",
       "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "dev": true,
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.6.tgz",
+      "integrity": "sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/visitor-keys": "5.59.6",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1657,140 +1684,59 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.6.tgz",
+      "integrity": "sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.6.tgz",
+      "integrity": "sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.59.6",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -4155,6 +4101,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -4868,9 +4820,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6290,6 +6242,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/natural-orderby": {
@@ -9173,9 +9131,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10016,6 +9974,29 @@
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -10884,6 +10865,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
@@ -10894,173 +10881,117 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.6.tgz",
+      "integrity": "sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/type-utils": "5.59.6",
+        "@typescript-eslint/utils": "5.59.6",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        },
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+          "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
           "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0",
-            "debug": "^4.3.1",
-            "globby": "^11.0.3",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          }
         }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.6.tgz",
+      "integrity": "sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.6.tgz",
+      "integrity": "sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/visitor-keys": "5.59.6"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.6.tgz",
+      "integrity": "sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "@typescript-eslint/utils": "5.59.6",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.6.tgz",
+      "integrity": "sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.6.tgz",
+      "integrity": "sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/visitor-keys": "5.59.6",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.6.tgz",
+      "integrity": "sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.6",
+        "@typescript-eslint/types": "5.59.6",
+        "@typescript-eslint/typescript-estree": "5.59.6",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.59.6",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.6.tgz",
+      "integrity": "sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.6",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+        "eslint-visitor-keys": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
           "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0",
-            "debug": "^4.3.1",
-            "globby": "^11.0.3",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "eslint-visitor-keys": "^2.0.0"
-          }
         }
       }
     },
@@ -12815,6 +12746,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -13342,9 +13279,9 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -14424,6 +14361,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "natural-orderby": {
@@ -16566,9 +16509,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@oclif/config": "^1.17.0",
     "@oclif/core": "^1.3.3",
     "@oclif/plugin-help": "^5.1.10",
+    "@clack/prompts": "^0.6.3",
     "async-mutex": "^0.4.0",
     "axios": "^0.27.2",
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.18",
-    "@typescript-eslint/eslint-plugin": "^4.21.0",
-    "@typescript-eslint/parser": "^4.21.0",
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
+    "@typescript-eslint/parser": "^5.21.0",
     "chai": "^4.3.4",
     "cross-spawn": "^7.0.3",
     "eslint": "^7.24.0",
@@ -29,7 +29,7 @@
     "sinon": "^14.0.0",
     "stdout-stderr": "^0.1.13",
     "ts-node": "^10.0.0",
-    "typescript": "^4.3.3"
+    "typescript": "^4.5.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -53,9 +53,11 @@ export default class APIError extends CLIError {
     return [
       [
         genericMessage,
-        `Please check the given ${chalk.underline('--documentation')}, ${chalk.underline(
-          '--token',
-        )} or ${chalk.underline('--hub')} flags`,
+        `In a hub context you might want to try the ${chalk.dim(
+          '--auto-create',
+        )} flag.\nOtherwise, please check the given ${chalk.dim(
+          '--documentation',
+        )}, ${chalk.dim('--token')} or ${chalk.dim('--hub')} flags`,
       ],
       104,
     ];

--- a/src/args.ts
+++ b/src/args.ts
@@ -2,7 +2,7 @@ const fileArg = {
   name: 'FILE',
   required: true,
   description:
-    'Path or URL to your API documentation file. OpenAPI (2.0 to 3.1.0) and AsyncAPI (2.x) specifications are currently supported.',
+    'Path or URL to your API documentation file. OpenAPI (2.0 to 3.1.0) and AsyncAPI (2.x) specifications are currently supported.\nPath can also be a directory when deploying to a Hub.',
 };
 
 const otherFileArg = {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -4,7 +4,7 @@ import { RequiredFlagError } from '@oclif/parser/lib/errors';
 import { CLIError } from '@oclif/errors';
 
 import Command from '../command';
-import * as flags from '../flags';
+import * as flagsBuilder from '../flags';
 import { DefinitionDirectory } from '../core/definition_directory';
 import { Deploy as CoreDeploy } from '../core/deploy';
 import { confirm as promptConfirm } from '../core/utils/prompts';
@@ -39,16 +39,16 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
   ];
 
   static flags = {
-    help: flags.help({ char: 'h' }),
-    doc: flags.doc(),
-    'doc-name': flags.docName(),
-    hub: flags.hub(),
-    branch: flags.branch(),
-    token: flags.token(),
-    'auto-create': flags.autoCreate(),
-    interactive: flags.interactive(),
-    'filename-pattern': flags.filenamePattern(),
-    'dry-run': flags.dryRun(),
+    help: flagsBuilder.help({ char: 'h' }),
+    doc: flagsBuilder.doc(),
+    'doc-name': flagsBuilder.docName(),
+    hub: flagsBuilder.hub(),
+    branch: flagsBuilder.branch(),
+    token: flagsBuilder.token(),
+    'auto-create': flagsBuilder.autoCreate(),
+    interactive: flagsBuilder.interactive(),
+    'filename-pattern': flagsBuilder.filenamePattern(),
+    'dry-run': flagsBuilder.dryRun(),
   };
 
   static args = [fileArg];

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,11 +1,17 @@
+import chalk from 'chalk';
+import { statSync } from 'fs';
+import { RequiredFlagError } from '@oclif/parser/lib/errors';
+import { CLIError } from '@oclif/errors';
+
 import Command from '../command';
 import * as flags from '../flags';
+import { DefinitionDirectory } from '../core/definition_directory';
 import { Deploy as CoreDeploy } from '../core/deploy';
+import { confirm as promptConfirm } from '../core/utils/prompts';
 import { fileArg } from '../args';
 import { cli } from '../cli';
 import { VersionResponse } from '../api/models';
-
-import { statSync } from 'fs';
+import { API } from '../definition';
 
 export default class Deploy extends Command {
   static description =
@@ -40,6 +46,8 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
     branch: flags.branch(),
     token: flags.token(),
     'auto-create': flags.autoCreate(),
+    interactive: flags.interactive(),
+    'filename-pattern': flags.filenamePattern(),
     'dry-run': flags.dryRun(),
   };
 
@@ -54,33 +62,133 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
   async run(): Promise<void> {
     const { args, flags } = this.parse(Deploy);
 
-    const [dryRun, documentation, token, hub, autoCreate, documentationName, branch] = [
+    const [
+      dryRun,
+      documentation,
+      token,
+      hub,
+      autoCreate,
+      interactive,
+      filenamePattern,
+      documentationName,
+      branch,
+    ] = [
       flags['dry-run'],
-      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-      flags.doc!,
+      flags.doc,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       flags.token!,
       flags.hub,
       flags['auto-create'],
+      flags.interactive,
+      /* Flags.filenamePattern has a default value, so it's always defined. But
+       * oclif types doesn't detect it */
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      flags['filename-pattern']!,
       flags['doc-name'],
       flags.branch,
     ];
     const file = await statSync(args.FILE);
 
     if (file.isDirectory()) {
-      throw new Error(
-        'Deploy with a directory is not yet implemented. Please wait while we are working on it!',
-      );
+      if (hub) {
+        await this.deployDirectory(
+          args.FILE,
+          dryRun,
+          token,
+          hub,
+          autoCreate,
+          interactive,
+          filenamePattern,
+          documentationName,
+          branch,
+        );
+      } else {
+        throw new RequiredFlagError({ flag: Deploy.flags.hub, parse: {} });
+      }
     } else {
-      await this.deploySingleFile(
-        args.FILE,
-        dryRun,
-        documentation,
-        token,
-        hub,
-        autoCreate,
-        documentationName,
-        branch,
+      if (documentation) {
+        const api = await API.load(args.FILE);
+        this.d(`${args.FILE} looks like an ${api.specName} spec version ${api.version}`);
+
+        await this.deploySingleFile(
+          api,
+          dryRun,
+          documentation,
+          token,
+          hub,
+          autoCreate,
+          documentationName,
+          branch,
+        );
+      } else {
+        throw new RequiredFlagError({ flag: Deploy.flags.doc, parse: {} });
+      }
+    }
+
+    return;
+  }
+
+  private async deployDirectory(
+    dir: string,
+    dryRun: boolean,
+    token: string,
+    hub: string,
+    autoCreate: boolean,
+    interactive: boolean,
+    filenamePattern: string,
+    documentationName: string | undefined,
+    branch: string | undefined,
+  ): Promise<void> {
+    const definitionDirectory = new DefinitionDirectory(dir, filenamePattern);
+    const action = dryRun ? 'validate' : 'deploy';
+
+    await definitionDirectory.readDefinitions();
+
+    // In “interactive” mode we ask the user if he wants to add more
+    // definitions to deploy. He is thus presented a form to select
+    // some files from the target directory.
+    if (interactive) {
+      let confirm = true;
+      if (definitionDirectory.definitionsExists()) {
+        await promptConfirm('Do you want to add more files to deploy?').catch(() => {
+          confirm = false;
+        });
+      }
+      if (confirm) {
+        await definitionDirectory.interactiveSelection();
+      }
+    }
+
+    if (definitionDirectory.definitionsExists()) {
+      cli.info(
+        chalk.underline(
+          `Let's ${action} those documentations to your ${hub} hub on Bump.sh`,
+        ),
+      );
+
+      await definitionDirectory.sequentialMap(async (definition) => {
+        if (interactive) {
+          await definitionDirectory.renameToConvention(definition);
+        }
+
+        await this.deploySingleFile(
+          definition.definition,
+          dryRun,
+          definition.slug,
+          token,
+          hub,
+          autoCreate,
+          definition.slug || documentationName,
+          branch,
+        );
+
+        return definition;
+      });
+    } else {
+      throw new CLIError(
+        `No documentations found in ${dir}.\nDo you need some help to name your API definition files?\nTry the ${chalk.dim(
+          '--interactive',
+        )} flag.`,
       );
     }
 
@@ -88,7 +196,7 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
   }
 
   private async deploySingleFile(
-    file: string,
+    api: API,
     dryRun: boolean,
     documentation: string,
     token: string,
@@ -98,10 +206,12 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
     branch: string | undefined,
   ): Promise<void> {
     const action = dryRun ? 'validate' : 'deploy';
-    cli.action.start(`* Let's ${action} a new documentation version on Bump`);
+    cli.action.start(
+      `Let's ${action} a new version to your ${documentation} documentation on Bump.sh`,
+    );
 
     const response: VersionResponse | undefined = await new CoreDeploy(this.config).run(
-      file,
+      api,
       dryRun,
       documentation,
       token,
@@ -111,19 +221,19 @@ $ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
       branch,
     );
 
-    cli.action.stop();
-
     if (dryRun) {
-      cli.styledSuccess('Definition is valid');
+      await cli.styledSuccess('Definition is valid');
     } else {
       if (response) {
-        cli.styledSuccess(
+        await cli.styledSuccess(
           `Your new documentation version will soon be ready at ${response.doc_public_url}`,
         );
       } else {
-        this.warn('Your documentation has not changed');
+        await cli.warn('Your documentation has not changed');
       }
     }
+
+    cli.action.stop();
 
     return;
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,21 +18,25 @@ export default class Deploy extends Command {
     'Create a new version of your documentation from the given file or URL.';
 
   static examples = [
-    `Deploy a new version of an existing documentation
+    `Deploy a new version of ${chalk.underline('an existing documentation')}
 
-$ bump deploy FILE --doc <your_doc_id_or_slug> --token <your_doc_token>
+${chalk.dim('$ bump deploy FILE --doc <your_doc_id_or_slug> --token <your_doc_token>')}
 * Let's deploy a new documentation version on Bump... done
 * Your new documentation version will soon be ready
 `,
-    `Deploy a new version of an existing documentation attached to a hub
+    `Deploy a new version of ${chalk.underline(
+      'an existing documentation attached to a hub',
+    )}
 
-$ bump deploy FILE --doc <doc_slug> --hub <your_hub_id_or_slug> --token <your_doc_token>
+${chalk.dim(
+  '$ bump deploy FILE --doc <doc_slug> --hub <your_hub_id_or_slug> --token <your_doc_token>',
+)}
 * Let's deploy a new documentation version on Bump... done
 * Your new documentation version will soon be ready
 `,
-    `Validate a new documentation version before deploying it
+    `${chalk.underline('Validate a new documentation version')} before deploying it
 
-$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>
+${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>')}
 * Let's validate a new documentation version on Bump... done
 * Definition is valid
 `,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -34,6 +34,24 @@ ${chalk.dim(
 * Let's deploy a new documentation version on Bump... done
 * Your new documentation version will soon be ready
 `,
+    `Deploy a whole directory of ${chalk.underline('API definitions files to a hub')}
+
+${chalk.dim(
+  '$ bump deploy DIR --filename-pattern *-{slug}-api --hub <hub_slug> --token <hub_token>',
+)}
+We've found 2 valid API definitions to deploy
+└─ DIR
+   └─ source-my-service-api.yml (OpenAPI spec version 3.1.0)
+   └─ source-my-jobs-service-api.yml (AsyncAPI spec version 2.6.0)
+
+Let's deploy those documentations to your <hub_slug> hub on Bump.sh
+
+* Your new documentation version will soon be ready
+Let's deploy a new version to your my-service documentation on Bump.sh... done
+
+* Your new documentation version will soon be ready
+Let's deploy a new version to your my-jobs-service documentation on Bump.sh... done
+`,
     `${chalk.underline('Validate a new documentation version')} before deploying it
 
 ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>')}
@@ -190,9 +208,11 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       });
     } else {
       throw new CLIError(
-        `No documentations found in ${dir}.\nDo you need some help to name your API definition files?\nTry the ${chalk.dim(
+        `No documentations found in ${dir}.\nYou should check the ${chalk.dim(
+          '--filename-pattern',
+        )} flag to select your files from your naming convention.\nIf you don't have a naming convention we can help naming your API definition files:\nTry the ${chalk.dim(
           '--interactive',
-        )} flag.`,
+        )} flag for that.`,
       );
     }
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,7 +1,7 @@
 import { CLIError } from '@oclif/errors';
 
 import Command from '../command';
-import * as flags from '../flags';
+import * as flagsBuilder from '../flags';
 import { Diff as CoreDiff } from '../core/diff';
 import { fileArg, otherFileArg } from '../args';
 import { cli } from '../cli';
@@ -44,15 +44,15 @@ export default class Diff extends Command {
   ];
 
   static flags = {
-    help: flags.help({ char: 'h' }),
-    doc: flags.doc(),
-    hub: flags.hub(),
-    branch: flags.branch(),
-    token: flags.token({ required: false }),
-    open: flags.open({ description: 'Open the visual diff in your browser' }),
-    'fail-on-breaking': flags.failOnBreaking(),
-    format: flags.format(),
-    expires: flags.expires(),
+    help: flagsBuilder.help({ char: 'h' }),
+    doc: flagsBuilder.doc(),
+    hub: flagsBuilder.hub(),
+    branch: flagsBuilder.branch(),
+    token: flagsBuilder.token({ required: false }),
+    open: flagsBuilder.open({ description: 'Open the visual diff in your browser' }),
+    'fail-on-breaking': flagsBuilder.failOnBreaking(),
+    format: flagsBuilder.format(),
+    expires: flagsBuilder.expires(),
   };
 
   static args = [fileArg, otherFileArg];

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -45,7 +45,7 @@ export default class Diff extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    doc: flags.doc({ required: false }),
+    doc: flags.doc(),
     hub: flags.hub(),
     branch: flags.branch(),
     token: flags.token({ required: false }),

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,6 +1,6 @@
 import { API } from '../definition';
 import Command from '../command';
-import * as flags from '../flags';
+import * as flagsBuilder from '../flags';
 import { fileArg } from '../args';
 import { cli } from '../cli';
 import { PreviewResponse, PreviewRequest } from '../api/models';
@@ -18,11 +18,13 @@ export default class Preview extends Command {
   ];
 
   static flags = {
-    help: flags.help({ char: 'h' }),
-    live: flags.live({
+    help: flagsBuilder.help({ char: 'h' }),
+    live: flagsBuilder.live({
       description: 'Generate a preview each time you save the given file',
     }),
-    open: flags.open({ description: 'Open the generated preview URL in your browser' }),
+    open: flagsBuilder.open({
+      description: 'Open the generated preview URL in your browser',
+    }),
   };
 
   static args = [fileArg];

--- a/src/core/definition_directory.ts
+++ b/src/core/definition_directory.ts
@@ -1,0 +1,204 @@
+import chalk from 'chalk';
+import debug from 'debug';
+import { rename } from 'fs';
+import { join, extname, dirname, resolve, basename } from 'node:path';
+import * as p from '@clack/prompts';
+import { CLIError } from '@oclif/errors';
+
+import { cli } from '../cli';
+import { API } from '../definition';
+import { File } from './utils/file';
+import { confirm as promptConfirm } from '../core/utils/prompts';
+
+export type DefinitionConfig = {
+  definition: API;
+  file: string;
+  slug: string;
+};
+
+export class DefinitionDirectory {
+  protected readonly path: string;
+  protected readonly definitions: DefinitionConfig[];
+
+  protected readonly filenamePattern: RegExp;
+  protected readonly humanFilenamePattern: string;
+  protected buildNewFilename: (slug: string) => string;
+
+  public constructor(directory: string, filenamePattern: string) {
+    this.path = resolve(directory);
+    this.definitions = [];
+    // Transform basic patterns '*' or '{text}' into a real RegExp
+    this.filenamePattern = new RegExp(
+      '^' + filenamePattern.replace('*', '.*?').replace(/{.*?}/, '(?<slug>.+?)') + '$',
+    );
+
+    this.buildNewFilename = (slug) =>
+      filenamePattern.replace('*', '').replace(/{.*?}/, slug);
+
+    this.humanFilenamePattern = filenamePattern.replace(
+      /{(.*?)}/,
+      `${chalk.inverse('{$1}')}`,
+    );
+  }
+
+  public async readDefinitions(): Promise<DefinitionConfig[]> {
+    for await (const { value, filename } of File.listValidConventionFiles(
+      this.path,
+      this.filenamePattern,
+    )) {
+      const file = join(this.path, value);
+      /* We already check the filenamePattern match inside the
+      `File.listValidConventionFiles` method so we are sure the group
+      matched exists. */
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      const slug = filename.match(this.filenamePattern)!.groups!.slug!;
+      const definition = await API.load(file);
+      this.definitions.push({
+        file,
+        definition,
+        slug,
+      });
+    }
+
+    if (this.definitions.length) {
+      cli.info(
+        chalk.underline(
+          `We've found ${this.definitions.length} valid API definitions to deploy`,
+        ),
+      );
+      const subtree = cli.tree();
+      this.definitions.forEach(({ file, definition }) =>
+        subtree.insert(
+          `${basename(file)} (${definition.specName} spec version ${definition.version})`,
+        ),
+      );
+      const tree = cli.tree();
+      tree.insert(this.path, subtree);
+
+      tree.display();
+      cli.info('');
+    }
+
+    return this.definitions;
+  }
+
+  public definitionsExists(): boolean {
+    return !!this.definitions.length;
+  }
+
+  public async sequentialMap(
+    callback: (definition: DefinitionConfig) => Promise<DefinitionConfig>,
+  ): Promise<void> {
+    for (const definition of this.definitions) {
+      await callback(definition);
+    }
+
+    return;
+  }
+
+  public async renameToConvention(documentation: DefinitionConfig): Promise<void> {
+    const { file, slug } = documentation;
+    if (basename(file, extname(file)).match(this.filenamePattern)) return;
+
+    // Default convention is defined in the flags.ts file for the
+    // 'filenamePattern' flag.
+    const newFilename = this.buildNewFilename(slug);
+    const newFile = `${dirname(file)}/${newFilename}${extname(file)}`;
+
+    let confirm = true;
+    await promptConfirm(
+      `Do you want to rename ${file} to ${newFile} (for later deployments)?`,
+    ).catch(() => {
+      confirm = false;
+    });
+
+    if (confirm) {
+      await rename(file, newFile, (err) => {
+        if (err) throw err;
+        cli.styledSuccess(`Renamed ${file} to ${newFile}.`);
+      });
+    }
+
+    return;
+  }
+
+  public async interactiveSelection(): Promise<DefinitionConfig[]> {
+    p.intro(
+      `This interactive form will help you rename your API contrat files to follow the expected naming convention.\n${chalk.gray(
+        '│  ',
+      )}Once finished, the selected files will be deployed to Bump.sh.\n${chalk.gray(
+        '│  ',
+      )}\n${chalk.gray('│  ')}File naming convention: ${
+        this.humanFilenamePattern
+      }${chalk.dim('.[json|yml|yaml]')}\n`,
+    );
+
+    const fileOptions = File.listInvalidConventionFiles(this.path, this.filenamePattern);
+    if (!fileOptions.length) {
+      throw new CLIError(
+        `No JSON or YAML files needing a rename were found in ${
+          this.path
+        }.\nAre you sure you need the ${chalk.dim('--interactive')} flag?`,
+      );
+    }
+    let shouldContinue = true;
+
+    while (shouldContinue) {
+      const filePrompt = {
+        fileName: () =>
+          p.select({
+            message: `Which file do you want to deploy from ${chalk.dim(this.path)}?`,
+            options: fileOptions,
+          }),
+      };
+      const groupPrompt = {
+        /* Results type should be taken from the previous prompts
+         * defined with clack/prompt  */
+        slug: ({ results }: { results: { fileName?: unknown } }) =>
+          p.text({
+            message: `What is the ${chalk.inverse(
+              'documentation slug',
+            )} for this ${chalk.dim(results.fileName as string)} file?`,
+          }),
+      };
+      const prompt = await p.group(
+        {
+          ...filePrompt,
+          ...groupPrompt,
+          shouldContinue: () =>
+            p.confirm({ message: 'Do you want to select another file?' }),
+        },
+        {
+          onCancel: () => {
+            p.cancel('Deploy cancelled.');
+            process.exit(0);
+          },
+        },
+      );
+
+      const file = join(this.path, prompt.fileName as string);
+      const definition = await API.load(file);
+      this.d(
+        `${file} looks like an ${definition.specName} spec version ${definition.version}`,
+      );
+
+      this.definitions.push({
+        file,
+        definition,
+        slug: prompt.slug,
+      });
+      shouldContinue = prompt.shouldContinue;
+    }
+
+    p.outro(`You're all set. Your deployments will start soon.`);
+
+    return this.definitions;
+  }
+
+  // Function signature type taken from @types/debug
+  // Debugger(formatter: any, ...args: any[]): void;
+  /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any */
+  d(formatter: any, ...args: any[]): void {
+    return debug(`bump-cli:core:interactive`)(formatter, ...args);
+  }
+}

--- a/src/core/deploy.ts
+++ b/src/core/deploy.ts
@@ -14,7 +14,7 @@ export class Deploy {
   }
 
   public async run(
-    file: string,
+    api: API,
     dryRun: boolean,
     documentation: string,
     token: string,
@@ -24,11 +24,7 @@ export class Deploy {
     branch: string | undefined,
   ): Promise<VersionResponse | undefined> {
     let version: VersionResponse | undefined = undefined;
-
-    const api = await API.load(file);
     const [definition, references] = api.extractDefinition();
-
-    this.d(`${file} looks like an ${api.specName} spec version ${api.version}`);
 
     const request: VersionRequest = {
       documentation,
@@ -99,6 +95,6 @@ export class Deploy {
   // Debugger(formatter: any, ...args: any[]): void;
   /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any */
   d(formatter: any, ...args: any[]): void {
-    return debug(`bump-cli:core:diff`)(formatter, ...args);
+    return debug(`bump-cli:core:deploy`)(formatter, ...args);
   }
 }

--- a/src/core/utils/file.ts
+++ b/src/core/utils/file.ts
@@ -1,0 +1,36 @@
+import { readdirSync } from 'fs';
+import { extname, basename } from 'path';
+
+type FileDescription = { value: string; label: string; filename: string };
+export class File {
+  protected static readonly supportedFormats = ['.yml', '.yaml', '.json'];
+
+  public static listValidConventionFiles(path: string, regex: RegExp): FileDescription[] {
+    return File.listValidFormatFiles(path).filter(({ filename }) => {
+      return filename.match(regex);
+    });
+  }
+
+  public static listInvalidConventionFiles(
+    path: string,
+    regex: RegExp,
+  ): FileDescription[] {
+    return File.listValidFormatFiles(path).filter(({ filename }) => {
+      return !filename.match(regex);
+    });
+  }
+
+  private static listValidFormatFiles(path: string): FileDescription[] {
+    return readdirSync(path)
+      .filter((file) => {
+        return File.supportedFormats.includes(extname(file));
+      })
+      .map((file) => {
+        return {
+          value: file,
+          label: basename(file),
+          filename: basename(file, extname(file)),
+        };
+      });
+  }
+}

--- a/src/core/utils/prompts.ts
+++ b/src/core/utils/prompts.ts
@@ -1,0 +1,22 @@
+import { CLIError } from '@oclif/errors';
+import * as p from '@clack/prompts';
+
+export const confirm = async (message = 'Continue?'): Promise<void> => {
+  const prompt = await p.group(
+    {
+      shouldContinue: () => p.confirm({ message: message }),
+    },
+    {
+      onCancel: () => {
+        p.cancel('Cancelled.');
+        process.exit(0);
+      },
+    },
+  );
+
+  if (!prompt.shouldContinue) {
+    throw new CLIError(`Cancelled`);
+  }
+
+  return;
+};

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -257,4 +257,4 @@ type AsyncAPI = JSONSchema4Object & {
   readonly info: string;
 };
 
-export { API };
+export { API, SupportedFormat };

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -33,8 +33,7 @@ const hub = flags.build({
 });
 
 const filenamePattern = flags.build({
-  char: 'p',
-  description: `Pattern to extract the documentation slug from filenames when deploying a DIRECTORY. Pattern uses only '*' and '{slug}' as special characters to extract the slug from a filename without extension. Used with --hub flag only. Defaults to '{slug}-api'`,
+  description: `Pattern to extract the documentation slug from filenames when deploying a DIRECTORY. Pattern uses only '*' and '{slug}' as special characters to extract the slug from a filename without extension. Used with --hub flag only.`,
   default: '{slug}-api',
 });
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,10 +4,9 @@ import * as Parser from '@oclif/parser';
 // Re-export oclif flags https://oclif.io/docs/flags
 export * from '@oclif/command/lib/flags';
 
-// Custom flags for bum-cli
+// Custom flags for bump-cli
 const doc = flags.build({
   char: 'd',
-  required: true,
   description:
     'Documentation public id or slug. Can be provided via BUMP_ID environment variable',
   default: () => {
@@ -31,6 +30,12 @@ const hub = flags.build({
     if (envHub) return envHub;
     // Search hub id in .bump/config.json file?
   },
+});
+
+const filenamePattern = flags.build({
+  char: 'p',
+  description: `Pattern to extract the documentation slug from filenames when deploying a DIRECTORY. Pattern uses only '*' and '{slug}' as special characters to extract the slug from a filename without extension. Used with --hub flag only. Defaults to '{slug}-api'`,
+  default: '{slug}-api',
 });
 
 const branch = flags.build({
@@ -57,6 +62,15 @@ const autoCreate = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
   return flags.boolean({
     description:
       'Automatically create the documentation if needed (only available with a --hub flag). Documentation name can be provided with --doc-name flag. Default: false',
+    dependsOn: ['hub'],
+    ...options,
+  });
+};
+
+const interactive = (options = {}): Parser.flags.IBooleanFlag<boolean> => {
+  return flags.boolean({
+    description:
+      "Interactively create a configuration file to deploy a Hub (only available with a --hub flag). This will start an interactive process if you don't have a CLI configuration file. Default: false",
     dependsOn: ['hub'],
     ...options,
   });
@@ -122,6 +136,8 @@ export {
   branch,
   token,
   autoCreate,
+  interactive,
+  filenamePattern,
   dryRun,
   open,
   failOnBreaking,

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon';
 import base, { expect } from '@oclif/test';
 import * as Config from '@oclif/config';
 import nock from 'nock';
+import chalk from 'chalk';
 
 import { BumpApi } from '../../src/api';
 import { PreviewRequest } from '../../src/api/models';
@@ -11,6 +12,8 @@ import { PreviewRequest } from '../../src/api/models';
 nock.disableNetConnect();
 const root = path.join(__dirname, '../../');
 const test = base.add('config', () => Config.load(root));
+// Force no colors in output messages
+chalk.level = 0;
 
 describe('BumpApi HTTP client class', () => {
   describe('nominal authenticated API call', () => {


### PR DESCRIPTION
About #217 and [functional specifications](https://www.notion.so/bumpsh/Multiple-API-definitions-upload-6dd6debec355401f844992966e8b04bb) available on Notion.

This PR adds a new possibility to run `bump deploy /path/to/directory/` in order to deploy multiple API contrat files in one command.

Here is an example with two cases, first case is with a directory which has files that follow the given naming convention (with `--filename-pattern` flag), second case is with a directory which already has files that follow the naming convention but we want to add some more interactively (with `--interactive` flag).

By default if no `--filanme-pattern` flag is provided the convention will be `{slug}-api` for definition filenames.

:sparkles: 

![Peek 07-06-2023 20-02](https://github.com/bump-sh/cli/assets/904193/7d0640bf-dfb1-47d9-9d36-9d3fed7a2f89)
