### PR TITLE
Adapt CLI to receive 402 status from Bump API

### DIFF
--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -26,6 +26,9 @@ export default class APIError extends CLIError {
       case 401:
         [info, exit] = APIError.unauthenticated();
         break;
+      case 402:
+        [info, exit] = APIError.paymentRequired(httpError.response.data as Error);
+        break;
       case 404:
       case 400:
         [info, exit] = APIError.notFound(httpError.response.data as Error);
@@ -59,6 +62,13 @@ export default class APIError extends CLIError {
       ],
       104,
     ];
+  }
+
+  static paymentRequired(error: Error): MessagesAndExitCode {
+    const genericMessage =
+      error.message || 'You need to upgrade to a paid plan to perform this request.';
+
+    return [[genericMessage], 102];
   }
 
   static invalidDefinition(error: InvalidDefinitionError): MessagesAndExitCode {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -147,6 +147,31 @@ describe('deploy subcommand', () => {
         });
     });
 
+    describe('Payment required', () => {
+      test
+        .nock('https://bump.sh', (api) => {
+          api.post('/api/v1/versions').reply(402, {
+            message:
+              'You need to upgrade to a paid plan to perform this request. Please go to https://bump.sh/account/billing',
+          });
+        })
+        .stdout()
+        .stderr()
+        .command(['deploy', 'examples/valid/openapi.v3.json', '--doc', 'coucou'])
+        .catch((err) => {
+          expect(err.message).to.contain(
+            'You need to upgrade to a paid plan to perform this request. Please go to https://bump.sh/account/billing',
+          );
+          throw err;
+        })
+        .exit(102)
+        .it("Doesn't create a deployed version", ({ stdout }) => {
+          expect(stdout).to.not.contain(
+            'Your new documentation version will soon be ready',
+          );
+        });
+    });
+
     describe('Invalid dry-run deploy', () => {
       test
         .nock('https://bump.sh', (api) => api.post('/api/v1/validations').reply(422))


### PR DESCRIPTION
We are currently discussing to add a specific response to our Bump API, when resource (Api or Hub) is disabled
(which mean that resource owner has to upgrade its plan): https://github.com/bump-sh/bump/pull/3326

A possibility is to use HTTP status code 402 'Payment required': https://developer.mozilla.org/fr/docs/Web/HTTP/Status/402

With this PR, I tried to adapt our CLI to support such error code 402.

It's really open to discussion since it's almost my first 'true' PR on this repository.