### PR TITLE
Fix & improve release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ '15' ]
+        node_version: [ '16' ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && npm run build && oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run clean && npm run build && npm run lint",
-    "publish": "np --no-release-draft",
+    "release": "np --no-release-draft",
     "test": "mocha \"test/**/*.test.ts\"",
     "test-coverage": "nyc npm run test",
     "test-integration": "node ./test/integration.js",


### PR DESCRIPTION
This PR contains two commits:
- First one is to rename the custom publish/release script from `npm run publish` to `npm run release`
- Second one is to fix the release build in Github CI which is broken due to the usage of `node:` namespacing in some imports we introduced...