### PR TITLE
fix: deploy from a URL

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { statSync } from 'fs';
 import { RequiredFlagError } from '@oclif/parser/lib/errors';
 import { CLIError } from '@oclif/errors';
 
@@ -8,6 +7,7 @@ import * as flagsBuilder from '../flags';
 import { DefinitionDirectory } from '../core/definition_directory';
 import { Deploy as CoreDeploy } from '../core/deploy';
 import { confirm as promptConfirm } from '../core/utils/prompts';
+import { isDir } from '../core/utils/file';
 import { fileArg } from '../args';
 import { cli } from '../cli';
 import { VersionResponse } from '../api/models';
@@ -109,9 +109,8 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       flags['doc-name'],
       flags.branch,
     ];
-    const file = await statSync(args.FILE);
 
-    if (file.isDirectory()) {
+    if (isDir(args.FILE)) {
       if (hub) {
         await this.deployDirectory(
           args.FILE,

--- a/src/core/utils/file.ts
+++ b/src/core/utils/file.ts
@@ -1,7 +1,16 @@
-import { readdirSync } from 'fs';
+import { readdirSync, statSync } from 'fs';
 import { extname, basename } from 'path';
 
 type FileDescription = { value: string; label: string; filename: string };
+
+export const isDir = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch (e) {
+    return false;
+  }
+};
+
 export class File {
   protected static readonly supportedFormats = ['.yml', '.yaml', '.json'];
 


### PR DESCRIPTION
In 2.7.0 we introduced the “hub” deployment to deploy a whole
directory. However we introduced a constrait on the input file
parameter of the `deploy` command to be an object on the
filesystem (due to the usage of `fs.statSync` function).

This commit makes sure to not crash if we pass a URL string and want
to deploy from a URL (instead of a fs filepath).