### PR TITLE
fix: error message when documentation is not found

### DIFF
--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -55,9 +55,9 @@ export default class APIError extends CLIError {
         genericMessage,
         `In a hub context you might want to try the ${chalk.dim(
           '--auto-create',
-        )} flag.\nOtherwise, please check the given ${chalk.dim(
-          '--documentation',
-        )}, ${chalk.dim('--token')} or ${chalk.dim('--hub')} flags`,
+        )} flag.\nOtherwise, please check the given ${chalk.dim('--doc')}, ${chalk.dim(
+          '--token',
+        )} or ${chalk.dim('--hub')} flags`,
       ],
       104,
     ];


### PR DESCRIPTION
The error message was indicating the user to use `--documentation`
argument which doesn't exist, it should be `--doc`.