### PR TITLE
deps: make sure to force the minimum version of AsyncAPI spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "bump-cli",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bump-cli",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
-        "@asyncapi/specs": "^4.0.1",
+        "@asyncapi/specs": "^5.1.0",
         "@clack/prompts": "^0.6.3",
         "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.17.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.2.0.tgz",
-      "integrity": "sha512-V9bFzUGNXrpsyennEXNZaPvdoFYYoeUYYAGiQVYsGsUsF/IL/G40NpE9u6nPeXGj8sZgjKlUG6iP39T0DYtSlQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9726,9 +9726,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.2.0.tgz",
-      "integrity": "sha512-V9bFzUGNXrpsyennEXNZaPvdoFYYoeUYYAGiQVYsGsUsF/IL/G40NpE9u6nPeXGj8sZgjKlUG6iP39T0DYtSlQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
-    "@asyncapi/specs": "^4.0.1",
+    "@asyncapi/specs": "^5.1.0",
     "@clack/prompts": "^0.6.3",
     "@oclif/command": "^1.8.16",
     "@oclif/config": "^1.17.0",

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -7,8 +7,11 @@ import {
   JSONSchema4Object,
   JSONSchema6,
   JSONSchema6Object,
+  JSONSchema7,
 } from 'json-schema';
 import path from 'path';
+
+type SpecSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
 
 class SupportedFormat {
   static readonly openapi: Record<string, SpecSchema> = {
@@ -17,13 +20,13 @@ class SupportedFormat {
     '3.1': require('oas-schemas/schemas/v3.1/schema.json'),
   };
   static readonly asyncapi: Record<string, SpecSchema> = {
-    '2.0': asyncapi['2.0.0'],
-    '2.1': asyncapi['2.1.0'],
-    '2.2': asyncapi['2.2.0'],
-    '2.3': asyncapi['2.3.0'],
-    '2.4': asyncapi['2.4.0'],
-    '2.5': asyncapi['2.5.0'],
-    '2.6': asyncapi['2.6.0'],
+    '2.0': asyncapi.schemas['2.0.0'],
+    '2.1': asyncapi.schemas['2.1.0'],
+    '2.2': asyncapi.schemas['2.2.0'],
+    '2.3': asyncapi.schemas['2.3.0'],
+    '2.4': asyncapi.schemas['2.4.0'],
+    '2.5': asyncapi.schemas['2.5.0'],
+    '2.6': asyncapi.schemas['2.6.0'],
   };
 }
 
@@ -67,7 +70,7 @@ class API {
     }
   }
 
-  getSpec(definition: APIDefinition): Record<string, unknown> {
+  getSpec(definition: APIDefinition): SpecSchema {
     if (API.isAsyncAPI(definition)) {
       return SupportedFormat.asyncapi[this.versionWithoutPatch()];
     } else {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,15 +1,6 @@
 // oas-schemas doesn't define TS types
 declare module 'oas-schemas';
 
-type SpecSchema = Record<string, unknown>;
-
-// AsyncAPI doesn't define TS types
-declare module '@asyncapi/specs' {
-  const asyncapi: Record<string, SpecSchema>;
-
-  export default asyncapi;
-}
-
 // Internals of json-schema-ref-parser doesn't expose types
 declare module '@apidevtools/json-schema-ref-parser/lib/options';
 


### PR DESCRIPTION
This commit makes sure to update the minimal version of the
`@asyncapi/spec` package which was locked to a version supporting
asyncapi 2.6.0, but not changed in the package.json file.

With this commit we make sure to always support asyncapi 2.6.0 even
for already existing installation (or cli used as a lib - in the
github-action for example).