### PR TITLE
deploy: better error message when no docs found in directory deploy

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -211,7 +211,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       });
     } else {
       throw new CLIError(
-        `No documentations found in ${dir} with pattern '${filenamePattern}'.\nYou should check with the ${chalk.dim(
+        `No documentation found in ${dir} with the pattern '${filenamePattern}'.\nYou should check with the ${chalk.dim(
           '--filename-pattern',
         )} flag to select your files from your naming convention.\nIf you don't have a naming convention we can help naming your API definition files:\nTry the ${chalk.dim(
           '--interactive',

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -211,7 +211,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       });
     } else {
       throw new CLIError(
-        `No documentations found in ${dir}.\nYou should check the ${chalk.dim(
+        `No documentations found in ${dir} with pattern '${filenamePattern}'.\nYou should check with the ${chalk.dim(
           '--filename-pattern',
         )} flag to select your files from your naming convention.\nIf you don't have a naming convention we can help naming your API definition files:\nTry the ${chalk.dim(
           '--interactive',


### PR DESCRIPTION
This commit improves the error message when no documentations are
found in the target directory to deploy by providing the filename
pattern valued used by the CLI to find doc files.