### PR TITLE
diff: increase timeout to 2min

### DIFF
--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -13,6 +13,9 @@ import {
 } from '../api/models';
 
 export class Diff {
+  // 120 seconds = 2 minutes
+  static readonly TIMEOUT = 120;
+
   _bump!: BumpApi;
   _config: Config.IConfig;
 
@@ -57,7 +60,7 @@ export class Diff {
 
     if (diffVersion) {
       return await this.waitResult(diffVersion, token, {
-        timeout: 30,
+        timeout: Diff.TIMEOUT,
         format,
       });
     } else {
@@ -155,7 +158,7 @@ export class Diff {
 
     if (opts.timeout <= 0) {
       throw new CLIError(
-        'We were unable to compute your documentation diff. Sorry about that. Please try again later',
+        'We were unable to compute your documentation diff. Sorry about that. Please try again later. If the error persists, please contact support at https://bump.sh.',
       );
     }
 

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -304,7 +304,7 @@ describe('diff subcommand', () => {
             .once()
             .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
             .get('/api/v1/versions/123')
-            .times(31)
+            .times(121)
             .reply(202);
         })
         .stdout()


### PR DESCRIPTION
We decided in the past to hard code a 30s timeout for a diff within
the CLI, but this is quite problematic especially if we have too much
traffic at the same time.

Until we have more power in our queuing system, I believe it's best to
allow a bit more time before failing.

This commit increases the timeout value by 3. Going from 30seconds to
2 minutes.