### PR TITLE
Let's render a preview on Bump.sh

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -51,7 +51,7 @@ export default class Preview extends Command {
     this.d(`${file} looks like an ${api.specName} spec version ${api.version}`);
 
     if (!currentPreview) {
-      cli.action.start("* Let's render a preview on Bump");
+      cli.action.start("* Let's render a preview on Bump.sh");
     }
 
     const request: PreviewRequest = {

--- a/test/commands/preview.test.ts
+++ b/test/commands/preview.test.ts
@@ -17,7 +17,7 @@ describe('preview subcommand', () => {
       .stderr()
       .command(['preview', 'examples/valid/openapi.v3.json'])
       .it('Creates a preview from an openapi file', ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's render a preview on Bump... done/);
+        expect(stderr).to.match(/Let's render a preview on Bump.sh... done/);
 
         expect(stdout).to.match(/preview is visible at/);
         expect(stdout).to.match(/https:\/\/bump.sh\/preview\/123abc-cba321/);
@@ -35,7 +35,7 @@ describe('preview subcommand', () => {
       .stderr()
       .command(['preview', '--live', 'examples/valid/openapi.v3.json'])
       .it('Creates a live preview and waits for file update', ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's render a preview on Bump... done/);
+        expect(stderr).to.match(/Let's render a preview on Bump.sh... done/);
 
         expect(stdout).to.match(/preview is visible at/);
         expect(stdout).to.match(/https:\/\/bump.sh\/preview\/123abc-cba321/);
@@ -61,7 +61,7 @@ describe('preview subcommand', () => {
       .stderr()
       .command(['preview', 'examples/valid/asyncapi.v2.yml'])
       .it('Creates a preview from an asyncapi file with $refs', ({ stdout, stderr }) => {
-        expect(stderr).to.match(/Let's render a preview on Bump... done/);
+        expect(stderr).to.match(/Let's render a preview on Bump.sh... done/);
 
         expect(stdout).to.match(/preview is visible at/);
         expect(stdout).to.match(/https:\/\/bump.sh\/preview\/123abc-cba321/);


### PR DESCRIPTION
Favor Bump.sh instead of Bump.

Noticed by working on GitLab integration, cf
https://gitlab.com/Polo2/multi-documentations.