### PR TITLE
fix(overlay): backport of an upstream fix for remove action

### DIFF
--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -27,7 +27,7 @@ export class Overlay {
         // Is it a remove?
         if (action.hasOwnProperty('remove')) {
           while (true) {
-            const path = jsonpath.paths(spec, target, 1);
+            const path = jsonpath.paths(spec, target);
             if (path.length == 0) {
               break;
             }


### PR DESCRIPTION
This commit is a backport of
https://github.com/lornajane/openapi-overlays-js/pull/13/files.

To fix the issue of applying `remove` action on a target which is a
list. Before the fix it would remove only the first occurence of the
target. With this fix it removes all the occurences of the target
JSONPath.

Thanks @lcawl for reporting the issue!