### PR TITLE
diff: make sure to parse versions API response with any format diff

### DIFF
--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -209,7 +209,9 @@ export class Diff {
   isVersionWithDiff(
     result: (VersionResponse & WithDiff) | DiffResponse,
   ): result is VersionResponse & WithDiff {
-    return (result as VersionResponse & WithDiff).diff_summary !== undefined;
+    const { diff_summary, diff_markdown, diff_details } = result as VersionResponse &
+      WithDiff;
+    return (diff_summary || diff_markdown || diff_details) !== undefined;
   }
 
   extractDiff(versionWithDiff: VersionResponse & WithDiff): DiffResponse {

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -51,6 +51,40 @@ describe('diff subcommand', () => {
         api
           .post(
             '/api/v1/versions',
+            (body) => body.documentation === 'coucou' && !body.branch_name,
+          )
+          .once()
+          .reply(201, { id: '123', doc_public_url: 'http://localhost/doc/1' })
+          .get('/api/v1/versions/123')
+          .once()
+          .reply(202)
+          .get('/api/v1/versions/123')
+          .once()
+          .reply(200, { diff_details: [] });
+      })
+      .stdout()
+      .stderr()
+      .command([
+        'diff',
+        'examples/valid/openapi.v3.json',
+        '--doc',
+        'coucou',
+        '--format',
+        'json',
+      ])
+      .it(
+        'asks for a diff to Bump and returns the newly created version (no content change)',
+        async ({ stdout, stderr }) => {
+          expect(stderr).to.eq('');
+          expect(stdout).to.contain('[]');
+        },
+      );
+
+    test
+      .nock('https://bump.sh', (api) => {
+        api
+          .post(
+            '/api/v1/versions',
             (body) => body.documentation === 'coucou' && body.branch_name === 'next',
           )
           .once()


### PR DESCRIPTION
This change adapts the detection of the response of the /versions API
to check any of the existing formats for a content rather than only
checking the `version.diff_summary` field.

This will help to be able to return an empty array `[]` when asking
for the `--format json` (since we fixed the API return values last
week in https://github.com/bump-sh/bump/pull/5703)