### PR TITLE
Favor name  bump.sh

### DIFF
--- a/examples/invalid/asyncapi.yml
+++ b/examples/invalid/asyncapi.yml
@@ -1,7 +1,7 @@
 {
   "info": {
-    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
-    "title": "Bump Api",
+    "description": "This is the official Bump.sh API documentation. Obviously created with Bump.sh.\n",
+    "title": "Bump.sh Api",
     "version": "1.0"
   },
   "asyncapi": "2.0.0",

--- a/examples/invalid/openapi.yml
+++ b/examples/invalid/openapi.yml
@@ -1,7 +1,7 @@
 {
   "info": {
-    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
-    "title": "Bump Api",
+    "description": "This is the official Bump.sh API documentation. Obviously created with Bump.sh.\n",
+    "title": "Bump.sh Api",
     "version": "1.0"
   },
   "openapii": "3.0.2",

--- a/examples/valid/bump-api.json
+++ b/examples/valid/bump-api.json
@@ -12,7 +12,7 @@
                   "type": "string"
                 },
                 "references": {
-                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump.sh servers, like local files or internal URLs.",
                   "items": {
                     "$ref": "#/components/schemas/Reference"
                   },
@@ -74,7 +74,7 @@
                   "type": "string"
                 },
                 "references": {
-                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump.sh servers, like local files or internal URLs.",
                   "items": {
                     "$ref": "#/components/schemas/Reference"
                   },
@@ -159,8 +159,8 @@
     }
   },
   "info": {
-    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
-    "title": "Bump Api",
+    "description": "This is the official Bump.sh API documentation. Obviously created with Bump.sh.\n",
+    "title": "Bump.sh Api",
     "version": "1.0"
   },
   "openapi": "3.0.2",

--- a/examples/valid/openapi.v3.json
+++ b/examples/valid/openapi.v3.json
@@ -12,7 +12,7 @@
                   "type": "string"
                 },
                 "references": {
-                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump.sh servers, like local files or internal URLs.",
                   "items": {
                     "$ref": "#/components/schemas/Reference"
                   },
@@ -74,7 +74,7 @@
                   "type": "string"
                 },
                 "references": {
-                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump servers, like local files or internal URLs.",
+                  "description": "Import external references used by `definition`. It's usually resources not accessible by Bump.sh servers, like local files or internal URLs.",
                   "items": {
                     "$ref": "#/components/schemas/Reference"
                   },
@@ -163,8 +163,8 @@
     }
   },
   "info": {
-    "description": "This is the official Bump API documentation. Obviously created with Bump.\n",
-    "title": "Bump Api",
+    "description": "This is the official Bump.sh API documentation. Obviously created with Bump.sh.\n",
+    "title": "Bump.sh Api",
     "version": "1.0"
   },
   "openapi": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bump-cli",
-  "description": "The Bump CLI is used to interact with your API documentation hosted on Bump by using the API of developers.bump.sh",
+  "description": "The Bump CLI is used to interact with your API documentation hosted on Bump.sh by using the API of developers.bump.sh",
   "version": "2.9.0-0",
   "author": "Paul Bonaud <paulr@bump.sh>",
   "bin": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -21,13 +21,13 @@ export default class Deploy extends BaseCommand<typeof Deploy> {
     `Deploy a new version of ${chalk.underline('an existing documentation')}
 
 ${chalk.dim('$ bump deploy FILE --doc <your_doc_id_or_slug> --token <your_doc_token>')}
-* Let's deploy a new documentation version on Bump... done
+* Let's deploy on Bump.sh... done
 * Your new documentation version will soon be ready
 `,
     `Deploy a new version of ${chalk.underline('an existing documentation attached to a hub')}
 
 ${chalk.dim('$ bump deploy FILE --doc <doc_slug> --hub <your_hub_id_or_slug> --token <your_doc_token>')}
-* Let's deploy a new documentation version on Bump... done
+* Let's deploy on Bump.sh... done
 * Your new documentation version will soon be ready
 `,
     `Deploy a whole directory of ${chalk.underline('API definitions files to a hub')}
@@ -49,7 +49,7 @@ Let's deploy a new version to your my-jobs-service documentation on Bump.sh... d
     `${chalk.underline('Validate a new documentation version')} before deploying it
 
 ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_token>')}
-* Let's validate a new documentation version on Bump... done
+* Let's validate on Bump.sh... done
 * Definition is valid
 `,
   ]


### PR DESCRIPTION
Small contribution to the tool, noticed by reviewing big PR #587 

When we mention the cli itself, name is indeed 'bump'.
But I favored bump.sh each time we mention the organization behind this tool.  