### PR TITLE
fix: align exported core Diff interface with previous 2.8 signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "repository": "bump-sh/cli",
   "scripts": {
+    "prepare": "npm run build",
     "build": "shx rm -rf dist && tsc -b",
     "clean": "rm -rf dist/ oclif.manifest.json",
     "lint": "eslint . --ext .ts",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -59,10 +59,11 @@ class BumpApi {
   }
 
   // Check https://oclif.io/docs/config for details about Config.IConfig
-  public constructor(protected config: Config) {
+  public constructor(protected config?: Config) {
     const baseURL = `${vars.apiUrl}${vars.apiBasePath}`
+    const userAgent = config?.userAgent || 'bump-cli'
     const headers: {Authorization?: string; 'User-Agent': string} = {
-      'User-Agent': vars.apiUserAgent(config.userAgent),
+      'User-Agent': vars.apiUserAgent(userAgent),
     }
 
     this.client = axios.create({

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -105,7 +105,7 @@ export default class Diff extends BaseCommand<typeof Diff> {
 
     ux.action.status = '...diff on Bump.sh in progress'
 
-    const diff: DiffResponse | undefined = await new CoreDiff(this.bump).run(
+    const diff: DiffResponse | undefined = await new CoreDiff(this.config).run(
       args.file,
       args.otherFile,
       documentation,


### PR DESCRIPTION
This is a fix after the major upgrade of the CLI (in #587) where we
broke the interface of the exported core `Diff` class and made its
usage as a lib more complicated.

Let's align back to what it used to be, and even simplify the
interface by making the constructor argument optional.