### PR TITLE
feat: apply multiple overlays on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Or, with Yarn via
 yarn global add bump-cli
 ```
 
-### Add Bump.sh to your node project
+### Add Bump.sh to your Node project
 
 As our CLI is a node package, you can easily embed it into your project by adding the package to your `package.json` file, either with NPM
 
@@ -74,7 +74,7 @@ You can then use any Bump.sh commands with `npx` (same as `npm exec`)
 npx bump --help
 ```
 
-### How should I do if I'm not using npm ?
+### Can I install Bump.sh CLI without using NodeJS?
 
 Unfortunately, at the moment we only support the Node environment. However, you can download a standalone package directly from the [latest Github release](https://github.com/bump-sh/cli/releases) assets which you can run as a standalone binary. Or you can push your documentation using [our API](https://developers.bump.sh/) (advanced usage only).
 
@@ -267,7 +267,7 @@ To redirect the output of the command to a new file you can run the following:
 bump overlay api-document.yaml overlay-file.yaml > api-overlayed-document.yaml
 ```
 
-_**Note:** you can also apply the overlay during the [`bump deploy` command]((#bump-deploy-file)) with the new `--overlay` flag:_
+_Note: you can also apply overlays during the [`bump deploy` command]((#bump-deploy-file)) with the `--overlay` flag (which can be used multiples times):_
 
 ```shell
 bump deploy api-document.yaml --doc my-doc --token my-token --overlay overlay-file.yaml

--- a/examples/valid/overlay2.yaml
+++ b/examples/valid/overlay2.yaml
@@ -1,0 +1,11 @@
+overlay: 1.0.0
+info:
+  title: Add Feedback Link
+  version: 0.0.1
+actions:
+  - target: '$.info'
+    description: Add a feedback link to the API
+    update:
+      x-feedbackLink:
+        label: Submit Feedback
+        url: https://github.com/bump-sh-examples/train-travel-api/issues/new

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -146,7 +146,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
     autoCreate: boolean,
     documentationName: string | undefined,
     branch: string | undefined,
-    overlay?: string | undefined,
+    overlay?: string[] | undefined,
   ): Promise<void> {
     ux.action.status = `...a new version to your ${documentation} documentation`
 

--- a/src/core/deploy.ts
+++ b/src/core/deploy.ts
@@ -48,11 +48,17 @@ export class Deploy {
     autoCreate: boolean,
     documentationName: string | undefined,
     branch: string | undefined,
-    overlay?: string | undefined,
+    overlay?: string[] | undefined,
   ): Promise<VersionResponse | undefined> {
     let version: VersionResponse | undefined
     if (overlay) {
-      await api.applyOverlay(overlay)
+      /* eslint-disable no-await-in-loop */
+      // Alternatively we can apply all overlays in parallel
+      // https://stackoverflow.com/questions/48957022/unexpected-await-inside-a-loop-no-await-in-loop
+      for (const overlayFile of overlay) {
+        await api.applyOverlay(overlayFile)
+      }
+      /* eslint-enable no-await-in-loop */
     }
 
     const [definition, references] = api.extractDefinition()

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -150,12 +150,13 @@ class API {
   public async applyOverlay(overlayPath: string): Promise<void> {
     const overlay = await API.load(overlayPath)
     const overlayDefinition = overlay.definition
+    const currentDefinition = this.overlayedDefinition || this.definition
 
     if (!API.isOpenAPIOverlay(overlayDefinition)) {
       throw new Error(`${overlayPath} does not look like an OpenAPI overlay`)
     }
 
-    this.overlayedDefinition = await new Overlay().run(this.definition, overlayDefinition)
+    this.overlayedDefinition = await new Overlay().run(currentDefinition, overlayDefinition)
   }
 
   public extractDefinition(outputPath?: string): [string, APIReference[]] {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,8 +1,4 @@
 import {Flags, Interfaces} from '@oclif/core'
-// import * as Parser from '@oclif/parser';
-
-// Re-export oclif flags https://oclif.io/docs/flags
-// export * from '@oclif/command/lib/flags';
 
 // Custom flags for bump-cli
 const doc = Flags.custom<string>({
@@ -131,9 +127,10 @@ const out = Flags.custom<string>({
   description: 'Output file path',
 })
 
-const overlay = Flags.custom<string>({
+const overlay = Flags.custom<string[]>({
   char: 'o',
-  description: 'Path or URL of an overlay file to apply before deploying',
+  description: 'Path or URL of overlay file(s) to apply before deploying',
+  multiple: true,
 })
 
 export {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -136,6 +136,32 @@ describe('deploy subcommand', () => {
     })
   })
 
+  describe('Successful runs with overlays', () => {
+    it('sends new version to Bump', async () => {
+      nock('https://bump.sh')
+        .post('/api/v1/versions', (body) => body.documentation === 'coucou' && !body.branch_name)
+        .reply(201, {doc_public_url: 'http://localhost/doc/1'})
+
+      const {stderr, stdout} = await runCommand(
+        [
+          'deploy',
+          'examples/valid/openapi.v3.json',
+          '--doc',
+          'coucou',
+          '--overlay',
+          'examples/valid/overlay.yaml',
+          '--overlay',
+          'examples/valid/overlay2.yaml',
+        ].join(' '),
+      )
+      expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")
+      expect(stdout).to.contain(
+        'Your coucou documentation...has received a new deployment which will soon be ready at:',
+      )
+      expect(stdout).to.contain('http://localhost/doc/1')
+    })
+  })
+
   describe('Server errors', () => {
     describe('Authentication error', () => {
       it("Doesn't create a deployed version", async () => {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -139,8 +139,15 @@ describe('deploy subcommand', () => {
   describe('Successful runs with overlays', () => {
     it('sends new version to Bump', async () => {
       nock('https://bump.sh')
-        .post('/api/v1/versions', (body) => body.documentation === 'coucou' && !body.branch_name)
-        .reply(201, {doc_public_url: 'http://localhost/doc/1'})
+        .post(
+          '/api/v1/versions',
+          (body) =>
+            body.documentation === 'coucou' &&
+            !body.branch_name &&
+            body.definition.includes('Submit Feedback') &&
+            body.definition.includes("Protect Earth's Tree Tracker"),
+        )
+        .reply(201, {doc_public_url: 'http://localhost/doc/123-with-overlays'})
 
       const {stderr, stdout} = await runCommand(
         [
@@ -158,7 +165,7 @@ describe('deploy subcommand', () => {
       expect(stdout).to.contain(
         'Your coucou documentation...has received a new deployment which will soon be ready at:',
       )
-      expect(stdout).to.contain('http://localhost/doc/1')
+      expect(stdout).to.contain('http://localhost/doc/123-with-overlays')
     })
   })
 


### PR DESCRIPTION
This adds the ability for the deploy command to take multiple `--overlay` flags.

```
node ./bin/run.js deploy examples/valid/openapi.v3.json 
  --overlay=examples/valid/overlay.yaml 
  --overlay=examples/valid/overlay2.yaml
```

This was done to make life easier on the Speakeasy workflow, which will need us to apply one overlay for each SDK language produced, of which there may be many. It looks a bit like this at the moment, and keeping track of `openapi.codegen1.yaml` and `openapi.codegen2.yaml` is going to be frustrating.

```
  - name: Add TypeScript SDK Samples to OpenAPI
    run: |
      npx bump-cli overlay openapi.yaml \
        https://spec.speakeasy.com/bumpsh/bumpsh/train-travel-api-typescript-code-samples \
        > openapi.codegen1.yaml

  - name: Add PHP SDK Samples to OpenAPI
    run: |
      npx bump-cli overlay openapi.codegen1.yaml \
        https://spec.speakeasy.com/bumpsh/bumpsh/train-travel-api-php-code-samples \
        > openapi.codegen2.yaml

  - name: Deploy API documentation
    uses: bump-sh/github-action@v1
    with:
      doc: <your-doc-id-or-slug>
      token: ${{secrets.BUMP_TOKEN}}
      file: openapi.codegen2.yaml
```

I did not add this to the `overlay` subcommand because there is no way in oclif to have [multiple arguments](https://github.com/oclif/oclif/issues/190), only multiple flags like this deploy command, and that was all getting a bit complicated for a quick fix. 

I also only added a basic test that shows this doesn't explode, as there were no existing tests on overlays. Manual testing shows it does apply both. See the "Submit Feedback" link applied on this test doc: https://bump.sh/philsturgeon/hub/test-docs/doc/multiple-overlays