### PR TITLE
diff: add a `--no-fail-on-breaking` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Please note that by default the command will always exit with a
 successful return code. If you want to use this command in a CI
 environment and want the command to fail **in case of a breaking
 change**, you will need to add the `--fail-on-breaking` flag to your
-diff command.
+diff command. By default if the environment variable `CI=1` is present
+(in most continuous integration environment), the flag will be
+enabled. In that case you can disable to failures with
+`--no-fail-on-breaking` flag.
 
 #### Public API diffs
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ environment and want the command to fail **in case of a breaking
 change**, you will need to add the `--fail-on-breaking` flag to your
 diff command. By default if the environment variable `CI=1` is present
 (in most continuous integration environment), the flag will be
-enabled. In that case you can disable to failures with
+enabled. In that case you can disable the failures with
 `--no-fail-on-breaking` flag.
 
 #### Public API diffs

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -51,7 +51,7 @@ export default class Diff extends BaseCommand<typeof Diff> {
     branch: flagsBuilder.branch(),
     doc: flagsBuilder.doc(),
     expires: flagsBuilder.expires(),
-    'fail-on-breaking': flagsBuilder.failOnBreaking(),
+    'fail-on-breaking': flagsBuilder.failOnBreaking({allowNo: true}),
     format: flagsBuilder.format(),
     hub: flagsBuilder.hub(),
     token: flagsBuilder.token({required: false}),

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -97,7 +97,8 @@ const failOnBreaking = (opts: Partial<Interfaces.BooleanFlag<boolean>> = {}) => 
 
       return false
     },
-    description: 'Fail when diff contains a breaking change',
+    description:
+      'Fail when diff contains a breaking change. Defaults to false locally. In CI environments where the env variable CI=1 is set, it defaults to true.',
   })
 }
 


### PR DESCRIPTION
This commit adds a `--no-*` version of the `--fail-on-breaking` flag
on the diff command to be able to disable the default behavior within
CI enviroments (where CI=1 env var is set for instance). Indeed, in
those environment the flag was always forced to true (without being
well documented) until now.

About #623