### PR TITLE
scripts: align with oclif's defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   },
   "repository": "bump-sh/cli",
   "scripts": {
-    "prepare": "npm run build",
     "build": "shx rm -rf dist && tsc -b",
     "clean": "rm -rf dist/ oclif.manifest.json",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
This changes the available scripts of the package to align with Oclif
v4's defaults (as seen at
https://github.com/oclif/oclif/blob/356ac3253433bf52184e2ae75574ac09a02e4236/templates/cli/shared/package.json.ejs).

We don't need a prepare phase anymore which was causing issues during
the packaging phase.