### PR TITLE
Add isHttpUrl check and enhance error handling

### DIFF
--- a/src/core/utils/file.ts
+++ b/src/core/utils/file.ts
@@ -1,11 +1,28 @@
+import {CLIError} from '@oclif/core/errors'
 import {readdirSync, statSync} from 'node:fs'
 import {basename, extname} from 'node:path'
 
 type FileDescription = {filename: string; label: string; value: string}
 
-export const isDir = (path: string): boolean => {
+export const isDir = (path_or_url: string): boolean => {
+  if (isHttpUrl(path_or_url)) {
+    return false
+  }
+
   try {
-    return statSync(path).isDirectory()
+    return statSync(path_or_url).isDirectory()
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new CLIError(error)
+    }
+    return false
+  }
+}
+
+const isHttpUrl = (path: string): boolean => {
+  try {
+    const url = new URL(path)
+    return ['http:', 'https:'].includes(url.protocol)
   } catch {
     return false
   }

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -220,6 +220,12 @@ describe('deploy subcommand', () => {
       expect(error?.oclif?.exit).to.equal(2)
     })
 
+    it('Fails deploying an inexistant directory', async () => {
+      const {error} = await runCommand(['deploy', 'FILE', '--hub', 'coucou'].join(' '))
+      expect(error?.message).to.match(/no such file or directory/)
+      expect(error?.oclif?.exit).to.equal(2)
+    })
+
     it('exits with status 2 when no file argument is provided', async () => {
       const {error} = await runCommand(['deploy'].join(' '))
       expect(error?.oclif?.exit).to.equal(2)


### PR DESCRIPTION
Improved `isDir`: Now handles HTTP(S) URLs by excluding them as directories.
Added `isHttpUrl` function: Detects whether a given path is an HTTP(S) URL.
Better error handling: Uses `CLIError` to prevent crashes on statSync errors.