### PR TITLE
overlay: replace `jsonpath` by the more recent (and typed) `jsonpathly`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "axios": "^1.7.7",
         "chalk": "^5.3.0",
         "debug": "^4.3.7",
-        "jsonpath": "^1.1.1",
+        "jsonpathly": "^2.0.2",
         "mergician": "^2.0.2",
         "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#882d1caedb0bff825a1fd10728e7e3dc43912d37",
         "open": "^10.1.0"
@@ -4592,6 +4592,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/antlr4": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
+      "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
@@ -6079,7 +6088,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/default-browser": {
       "version": "5.2.1",
@@ -6825,99 +6835,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -7768,18 +7685,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -7959,7 +7864,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -10512,14 +10416,14 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+    "node_modules/jsonpathly": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsonpathly/-/jsonpathly-2.0.2.tgz",
+      "integrity": "sha512-aoJOF6ptGGNgRQaQJPU1s2gnnPp/NphaWNPGMGd8yB7mV3JzXFQJx12/2Y7bN9dFtLPfq783iVzNMbfth5cr/Q==",
+      "license": "MIT",
       "dependencies": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
+        "antlr4": "^4.13.1",
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/just-extend": {
@@ -14773,14 +14677,6 @@
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true
     },
-    "node_modules/static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dependencies": {
-        "escodegen": "^1.8.1"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -15552,11 +15448,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
-    },
     "node_modules/undici": {
       "version": "6.20.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
@@ -15910,6 +15801,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "axios": "^1.7.7",
     "chalk": "^5.3.0",
     "debug": "^4.3.7",
-    "jsonpath": "^1.1.1",
+    "jsonpathly": "^2.0.2",
     "mergician": "^2.0.2",
     "oas-schemas": "git+https://git@github.com/OAI/OpenAPI-Specification.git#882d1caedb0bff825a1fd10728e7e3dc43912d37",
     "open": "^10.1.0"

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -1,7 +1,6 @@
 import debug from 'debug'
-import {JSONSchema4Object} from 'json-schema'
-/* eslint-disable-next-line import/default */
-import jsonpath from 'jsonpath'
+import {JSONSchema4Object, JSONSchema4Type} from 'json-schema'
+import * as jsonpath from 'jsonpathly'
 import {mergician} from 'mergician'
 
 import {APIDefinition, OpenAPIOverlay} from '../definition.js'
@@ -24,64 +23,114 @@ export class Overlay {
   // If you make any changes here, PLEASE ALSO MAKE THEM UPSTREAM.
   public run(spec: APIDefinition, overlay: OpenAPIOverlay): APIDefinition {
     // Use jsonpath.apply to do the changes
-    if (overlay.actions && overlay.actions.length > 0)
+    if (overlay.actions && overlay.actions.length > 0) {
       for (const a of overlay.actions) {
         const action = a as JSONSchema4Object
         if (!action.target) {
-          process.stderr.write('Action with a missing target\n')
+          process.stderr.write(`WARNING: ${this.humanName(action)} has an empty target\n`)
           continue
         }
 
         const target = action.target as string
-        // Is it a remove?
-        if (Object.hasOwn(action, 'remove')) {
-          /* eslint-disable-next-line no-constant-condition */
-          while (true) {
-            const path = jsonpath.paths(spec, target)
-            if (path.length === 0) {
-              break
-            }
+        // jsonpathly's paths are strings. They represent a “Path
+        // expression” which represents the absolute path in the objet
+        // tree reached by our `target`.
+        //
+        // E.g. '$["store"]["book"][0]["price"]'
+        const paths = jsonpath.paths(spec, target)
+        if (paths.length === 0) {
+          process.stderr.write(`WARNING: Action target '${target}' has no matching elements\n`)
+          continue
+        }
 
-            const parent = jsonpath.parent(spec, target)
-            const thingToRemove = path[0].at(-1)
-            if (thingToRemove !== undefined) {
-              if (Array.isArray(parent)) {
-                parent.splice(thingToRemove as number, 1)
-              } else {
-                delete parent[thingToRemove]
-              }
-            }
-          }
-        } else {
-          try {
-            // It must be an update
-            // Deep merge objects using a module (built-in spread operator is only shallow)
-            const merger = mergician({appendArrays: true})
-            if (target === '$') {
-              // You can't actually merge an update on a root object
-              // target with the jsonpath lib, this is just us merging
-              // the given update with the whole spec.
-              spec = merger(spec, action.update)
-            } else {
-              jsonpath.apply(spec, target, (chunk) => {
-                if (typeof chunk === 'object' && typeof action.update === 'object') {
-                  if (Array.isArray(chunk) && Array.isArray(action.update)) {
-                    return [...chunk, ...action.update]
-                  }
-
-                  return merger(chunk, action.update)
-                }
-
-                return action.update
-              })
-            }
-          } catch (error) {
-            process.stderr.write(`Error applying overlay: ${(error as Error).message}\n`)
-            // return chunk
-          }
+        for (const path of paths) {
+          // The 'executeAction' will mutate the passed spec object in
+          // place.
+          this.executeAction(spec, action, path)
         }
       }
+    } else {
+      process.stderr.write('WARNING: No actions found in your overlay\n')
+    }
 
     return spec
+  }
+
+  /* Mutates the given 'spec' object with the 'action' given and
+   * targeting a unique 'pat ' within the spec object. We don't check
+   * if the path is valid in the object as this is the role of the
+   * jsonpathly lib which we used previously to extract the target
+   * paths. */
+  private executeAction(spec: APIDefinition, action: JSONSchema4Object, path: string): void {
+    const explodedPath: string[] = path.split(/(?:]\[|\$\[)+/)
+    // Remove root
+    explodedPath.shift()
+
+    // Take last element from path (which is the thing to act
+    // upon)
+    let thingToActUpon: number | string | undefined = explodedPath.pop()
+    // The last element (e.g. '"price"]' or '0]') contains a final ']'
+    // so we need to remove it AND we need to parse the element to
+    // transform the string in either a string or a number
+    thingToActUpon =
+      thingToActUpon === undefined ? '$' : (thingToActUpon = JSON.parse(thingToActUpon.slice(0, -1)) as number | string)
+
+    // Reconstruct the stringified path expression targeting the parent
+    const parentPath: string = explodedPath.join('][')
+    const parent: JSONSchema4Object =
+      parentPath.length > 0 ? (jsonpath.query(spec, `$[${parentPath}]`) as JSONSchema4Object) : spec
+
+    // Do the overlay action
+    // Is it a remove?
+    if (Object.hasOwn(action, 'remove')) {
+      this.remove(parent, thingToActUpon)
+    } else if (Object.hasOwn(action, 'update')) {
+      this.update(spec, parent, action.update, thingToActUpon)
+    } else {
+      process.stderr.write(`WARNING: ${this.humanName(action)} needs either a 'remove' or an 'update' property\n`)
+    }
+  }
+
+  private humanName(action: JSONSchema4Object): string {
+    return action.description ? `Action '${action.description}'` : 'Action'
+  }
+
+  private remove(parent: JSONSchema4Object, property_or_index: number | string): void {
+    if (Array.isArray(parent)) {
+      parent.splice(property_or_index as number, 1)
+    } else {
+      delete parent[property_or_index]
+    }
+  }
+
+  private update(
+    spec: APIDefinition,
+    parent: JSONSchema4Object,
+    update: JSONSchema4Type,
+    property_or_index: number | string,
+  ): void {
+    try {
+      // Deep merge objects using a module (built-in spread operator is only shallow)
+      const merger = mergician({appendArrays: true})
+      if (property_or_index === '$') {
+        // You can't actually merge an update on a root object
+        // target with the jsonpathly lib, this is just us merging
+        // the given update with the whole spec.
+        spec = merger(spec, update)
+      } else if (property_or_index) {
+        const targetObject = parent[property_or_index]
+
+        if (typeof targetObject === 'object' && typeof update === 'object') {
+          parent[property_or_index] =
+            Array.isArray(targetObject) && Array.isArray(update)
+              ? [...targetObject, ...update]
+              : merger(targetObject, update)
+        } else {
+          parent[property_or_index] = update
+        }
+      }
+    } catch (error) {
+      process.stderr.write(`Error applying overlay: ${(error as Error).message}\n`)
+    }
   }
 }


### PR DESCRIPTION
The currently used `jsonpath` lib is pretty old and unmaintained (last
commits 4 years ago), and even more problematic it causes issues to
[upgrade our github action](https://github.com/bump-sh/github-action/pull/508) as that lib has an inconsistant use of
'require' and doesn't seem to work well with the packaging
step (rollup) of the github action.

Hopefully this upgrade (and change of lib) should let us a clean
upgrade of the GH action to an ESM version 🤞

As I re-wrote the way we apply overlays I also took the opportunity to fix #588 in this change.