### PR TITLE
Readme: Add instructions to run CLI in local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ bump --help
 The Bump.sh CLI is used to interact with your API documentation hosted on Bump.sh by using the API of developers.bump.sh
 
 VERSION
-  bump-cli/2.9.2 linux-x64 node-v20.18.1
+  bump-cli/2.9.3 linux-x64 node-v20.18.1
 
 USAGE
   $ bump [COMMAND]

--- a/README.md
+++ b/README.md
@@ -325,10 +325,35 @@ Make sure to have Node.js (At least v20) installed on your machine.
   ```
 
 - Run the test suites
-  
+
   ```shell
   npm run test
   npm run test-coverage # Run tests with coverage
+  ```
+
+### Use package in local environment
+
+You can run the package by executing the file `bin/run.js` locally:
+
+  ```shell
+  bin/run.js
+  ```
+
+For example to generate a preview:
+
+  ```shell
+  ./bin/run.js preview path/to/file.json
+  > Your preview is visible at: https://bump.sh/preview/42
+  ```
+
+Please note that even if CLI is running locally, by default requests are sent to [Bump.sh API](https://developers.bump.sh/).
+
+If you have a local version of the Bump.sh API, you can run CLI 100% in local environment
+by setting the environment variable `BUMP_HOST`:
+
+  ```shell
+  BUMP_HOST="http://localhost:3000" ./bin/run.js preview path/to/file.json
+  > Your preview is visible at: http://localhost:3000/preview/42
   ```
 
 ## License


### PR DESCRIPTION
Mention how to run and use CLI in local environment.

Bonus: 2nd commit upgrade bump-cli version in README to 2.9.3