### PR TITLE
Add flag '--preview' to Deploy command

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -36,6 +36,7 @@ export interface VersionRequest {
   hub?: string
   previous_version_id?: string
   references?: Reference[]
+  temporary?: boolean
   unpublished?: boolean
 }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -64,6 +64,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
     hub: flagsBuilder.hub(),
     interactive: flagsBuilder.interactive(),
     overlay: flagsBuilder.overlay(),
+    preview: flagsBuilder.preview(),
     token: flagsBuilder.token(),
   }
 
@@ -147,6 +148,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
     documentationName: string | undefined,
     branch: string | undefined,
     overlay?: string[] | undefined,
+    temporary?: boolean | undefined,
   ): Promise<void> {
     ux.action.status = `...a new version to your ${documentation} documentation`
 
@@ -160,13 +162,16 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       documentationName,
       branch,
       overlay,
+      temporary,
     )
 
     if (dryRun) {
       ux.stdout(ux.colorize('green', 'Definition is valid'))
     } else if (response) {
       process.stdout.write(ux.colorize('green', `Your ${documentation} documentation...`))
-      ux.stdout(ux.colorize('green', `has received a new deployment which will soon be ready at:`))
+      ux.stdout(
+        ux.colorize('green', `has received a new ${temporary ? 'preview' : 'deployment'} which will soon be ready at:`),
+      )
       ux.stdout(ux.colorize('underline', response.doc_public_url!))
     } else {
       ux.warn(`Your ${documentation} documentation has not changed`)
@@ -193,6 +198,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       documentationName,
       branch,
       overlay,
+      temporary,
     ] = [
       flags['dry-run'],
       flags.doc,
@@ -208,9 +214,11 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
       flags['doc-name'],
       flags.branch,
       flags.overlay,
+      /* when --preview is provided, generate temporary version */
+      flags.preview,
     ]
 
-    const action = dryRun ? 'validate' : 'deploy'
+    const action = dryRun ? 'validate' : temporary ? 'preview' : 'deploy'
     ux.action.start(`Let's ${action} on Bump.sh`)
 
     if (isDir(args.file)) {
@@ -243,6 +251,7 @@ ${chalk.dim('$ bump deploy FILE --dry-run --doc <doc_slug> --token <your_doc_tok
         documentationName,
         branch,
         overlay,
+        temporary,
       )
     } else {
       throw new CLIError('Missing required flag --doc=<slug>')

--- a/src/core/deploy.ts
+++ b/src/core/deploy.ts
@@ -49,6 +49,7 @@ export class Deploy {
     documentationName: string | undefined,
     branch: string | undefined,
     overlay?: string[] | undefined,
+    temporary?: boolean | false,
   ): Promise<VersionResponse | undefined> {
     let version: VersionResponse | undefined
     if (overlay) {
@@ -71,6 +72,7 @@ export class Deploy {
       documentation_name: documentationName,
       hub,
       references,
+      temporary,
     }
     if (dryRun) {
       await this.validateVersion(request, token)

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -110,6 +110,16 @@ const live = (opts: Partial<Interfaces.BooleanFlag<boolean>> = {}) => {
   })
 }
 
+const preview = (opts: Partial<Interfaces.BooleanFlag<boolean>> = {}) => {
+  return Flags.boolean({
+    ...opts,
+    char: 'p',
+    default: false,
+    description:
+      'Generate a preview in your API context. The resulting version is temporary and not visible by your documentation viewers.',
+  })
+}
+
 const format = Flags.custom<string>({
   char: 'f',
   default: 'text',
@@ -150,5 +160,6 @@ export {
   open,
   out,
   overlay,
+  preview,
   token,
 }

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -169,6 +169,22 @@ describe('deploy subcommand', () => {
     })
   })
 
+  describe('Successful runs with option preview', () => {
+    it('sends new version to Bump and receive temporary version', async () => {
+      nock('https://bump.sh')
+        .post('/api/v1/versions', (body) => body.documentation === 'tempy' && body.temporary)
+        .reply(201, {doc_public_url: 'http://localhost/doc/1'})
+
+      const {stderr, stdout} = await runCommand(
+        ['deploy', 'examples/valid/openapi.v3.json', '--doc', 'tempy', '--preview'].join(' '),
+      )
+
+      expect(stderr).to.contain("Let's preview on Bump.sh... done\n")
+      expect(stdout).to.contain('Your tempy documentation...has received a new preview which will soon be ready at:')
+      expect(stdout).to.contain('http://localhost/doc/1')
+    })
+  })
+
   describe('Server errors', () => {
     describe('Authentication error', () => {
       it("Doesn't create a deployed version", async () => {


### PR DESCRIPTION
Allow user to deploy a new version  temporary, deployed in the context of the API (logo, CSS, group by tag/path ...).

In this commit, we add a new tag `--preview`,
that can be added to `bump deploy` command.
Output is a temporary version, accessible by a link
visible in CLI response, and invisible in deployment list on Bump.sh workspace.


As described here: https://github.com/bump-sh/cli/issues/381#issuecomment-2724350235



---

following #381