### PR TITLE
Improve config load with resolve

### DIFF
--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,6 +1,7 @@
 import {Config} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
 import debug from 'debug'
+import {resolve} from 'node:path'
 
 import {BumpApi} from '../api/index.js'
 import {DiffRequest, DiffResponse, VersionRequest, VersionResponse, WithDiff} from '../api/models.js'
@@ -134,7 +135,7 @@ export class Diff {
     format: string,
     expires: string | undefined,
   ): Promise<DiffResponse | undefined> {
-    if (!this._config) this._config = await Config.load('../../')
+    if (!this._config) this._config = await Config.load(resolve(import.meta.dirname, './../../'))
 
     let diffVersion: DiffResponse | VersionResponse | undefined
 

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai'
 import chalk from 'chalk'
 import nock from 'nock'
 import * as os from 'node:os'
+import {resolve} from 'node:path'
 import {spy, stub} from 'sinon'
 
 import {BumpApi} from '../../src/api'
@@ -12,7 +13,7 @@ nock.disableNetConnect()
 // Force no colors in output messages
 chalk.level = 0
 // Default oclif config from root of repo
-const config = await Config.load('../../')
+const config = await Config.load(resolve(import.meta.dirname, './../../'))
 
 describe('BumpApi HTTP client class', () => {
   describe('nominal authenticated API call', () => {


### PR DESCRIPTION
I noticed that `Config.load('../../')` was not enough in my environment, and was loading an incorrect directory, starting from the projet directory instead of the current file directory.

---

noticed by working on #679 