### PR TITLE
fix(overlay): make sure root updates and array[0] updates work

### DIFF
--- a/examples/valid/openapi.v3.json
+++ b/examples/valid/openapi.v3.json
@@ -254,6 +254,11 @@
       "url": "https://bump.sh/api/v1"
     }
   ],
+  "tags": [
+    {
+      "name": "test"
+    }
+  ],
   "x-topics": [
     {
       "content": "# Api token authentication\n\nUse the token from your documentation settings as the username of the basic auth, with no password.\n\nExample: `curl https://bump.sh/api/v1/docs/1/versions -u DOC_TOKEN:`\n\nNote that adding a colon after your token prevents cURL from asking for a password.\n",

--- a/examples/valid/overlay.yaml
+++ b/examples/valid/overlay.yaml
@@ -3,6 +3,13 @@ info:
   title: Overlay to customise API for Protect Earth
   version: 0.0.1
 actions:
+  - target: '$'
+    description: Add an extra x-topic
+    update:
+      x-topics:
+        - title: Getting started
+          content: |
+            Use this API directly in your browser with the API explorer!
   - target: '$.info.description'
     description: Provide a better introduction for our end users than this techno babble.
     update: |
@@ -34,3 +41,8 @@ actions:
     update:
       - description: Production
         url: https://api.protect.earth/
+
+  - target: '$.tags[?(@.name=="test")]'
+    update:
+      description: |
+        This is my test description

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -46,7 +46,7 @@ export class Overlay {
         for (const path of paths) {
           // The 'executeAction' will mutate the passed spec object in
           // place.
-          this.executeAction(spec, action, path)
+          spec = this.executeAction(spec, action, path)
         }
       }
     } else {
@@ -61,7 +61,7 @@ export class Overlay {
    * if the path is valid in the object as this is the role of the
    * jsonpathly lib which we used previously to extract the target
    * paths. */
-  private executeAction(spec: APIDefinition, action: JSONSchema4Object, path: string): void {
+  private executeAction(spec: APIDefinition, action: JSONSchema4Object, path: string): APIDefinition {
     const explodedPath: string[] = path.split(/(?:]\[|\$\[)+/)
     // Remove root
     explodedPath.shift()
@@ -85,10 +85,12 @@ export class Overlay {
     if (Object.hasOwn(action, 'remove')) {
       this.remove(parent, thingToActUpon)
     } else if (Object.hasOwn(action, 'update')) {
-      this.update(spec, parent, action.update, thingToActUpon)
+      spec = this.update(spec, parent, action.update, thingToActUpon)
     } else {
       process.stderr.write(`WARNING: ${this.humanName(action)} needs either a 'remove' or an 'update' property\n`)
     }
+
+    return spec
   }
 
   private humanName(action: JSONSchema4Object): string {
@@ -108,7 +110,7 @@ export class Overlay {
     parent: JSONSchema4Object,
     update: JSONSchema4Type,
     property_or_index: number | string,
-  ): void {
+  ): APIDefinition {
     try {
       // Deep merge objects using a module (built-in spread operator is only shallow)
       const merger = mergician({appendArrays: true})
@@ -132,5 +134,7 @@ export class Overlay {
     } catch (error) {
       process.stderr.write(`Error applying overlay: ${(error as Error).message}\n`)
     }
+
+    return spec
   }
 }

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -119,7 +119,7 @@ export class Overlay {
         // target with the jsonpathly lib, this is just us merging
         // the given update with the whole spec.
         spec = merger(spec, update)
-      } else if (property_or_index) {
+      } else if (property_or_index !== undefined) {
         const targetObject = parent[property_or_index]
 
         if (typeof targetObject === 'object' && typeof update === 'object') {

--- a/test/commands/overlay.test.ts
+++ b/test/commands/overlay.test.ts
@@ -1,5 +1,6 @@
 import {runCommand} from '@oclif/test'
 import {expect} from 'chai'
+import {existsSync} from 'node:fs'
 import {rm} from 'node:fs/promises'
 
 describe('overlay subcommand', () => {
@@ -22,6 +23,8 @@ describe('overlay subcommand', () => {
       expect(overlayedDefinition.servers[0].description).to.equal('Production')
       // Target on nodes which have "x-beta":true field
       expect(overlayedDefinition.components.schemas.Pong.properties).to.have.all.keys('pong')
+      expect(overlayedDefinition.tags[0].description).to.equal('This is my test description\n')
+      expect(overlayedDefinition['x-topics'].length).to.equal(2)
     })
 
     it('Stores the result to the target output file argument', async () => {
@@ -38,6 +41,9 @@ describe('overlay subcommand', () => {
       expect(stderr).to.contain("Let's apply the overlay to the main definition")
       /* eslint-disable-next-line @typescript-eslint/no-unused-expressions */
       expect(stdout).to.be.empty
+      /* eslint-disable-next-line @typescript-eslint/no-unused-expressions */
+      expect(existsSync('tmp/openapi.overlayed.json')).to.be.true
+
       // Cleanup created file
       await rm('tmp/openapi.overlayed.json')
     })


### PR DESCRIPTION
These two cases (updating the root object, and, updating the first element of an array) was not tested in our unit tests and were both broken by the previous overlay core refactoring (#673). 🤯

Thanks a lot to @lcawl for reporting this issue 🙇

Closes https://github.com/bump-sh/bump/issues/6579