### PR TITLE
fix(overlay): fix removal of elements of an array

### DIFF
--- a/examples/valid/openapi.v3.json
+++ b/examples/valid/openapi.v3.json
@@ -252,6 +252,12 @@
   "servers": [
     {
       "url": "https://bump.sh/api/v1"
+    },
+    {
+      "url": "https://staging.bump.sh/api/v1"
+    },
+    {
+      "url": "http://localhost:3000/api/v1"
     }
   ],
   "tags": [

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -43,6 +43,24 @@ export class Overlay {
           continue
         }
 
+        // When we execute a 'remove' action we need to be careful if
+        // the targets are elements of an array. Because the list of
+        // paths contains an index of each element.
+        //
+        // E.g.
+        // ["servers"][0]
+        // ["servers"][1]
+        // ["servers"][2]
+        //
+        // And if we remove elements starting from the 0, the array
+        // will be reindexed and thus the '2' index won't be valid
+        // anymore.
+        //
+        // Thus, in that case we revers the list of paths
+        if (action.remove) {
+          paths.reverse()
+        }
+
         for (const path of paths) {
           // The 'executeAction' will mutate the passed spec object in
           // place.
@@ -83,8 +101,10 @@ export class Overlay {
     // Do the overlay action
     // Is it a remove?
     if (Object.hasOwn(action, 'remove')) {
+      this.d(`Executing 'remove' on target path: ${path}`)
       this.remove(parent, thingToActUpon)
     } else if (Object.hasOwn(action, 'update')) {
+      this.d(`Executing 'update' on target path: ${path}`)
       spec = this.update(spec, parent, action.update, thingToActUpon)
     } else {
       process.stderr.write(`WARNING: ${this.humanName(action)} needs either a 'remove' or an 'update' property\n`)


### PR DESCRIPTION
With the refactoring made on the overlay command in
[v2.9.3](https://github.com/bump-sh/cli/releases/tag/v2.9.3) we
introduced a bug when `remove`ing elements if the overlay action was
targeting an array.

This was due to the exploded json paths which contains indexes, and
that those index change each time we remove an element.

We've fixed the bug with @AurelDbs by iterating over the list of paths
in a reversed order (we start by the end of the array instead of the
beginning).

_Note: once again, thanks @lcawl for reporting this issue! And sorry
for the unexpected behavior 🙂_