### PR TITLE
fix(overlay): don't output yaml anchors

### DIFF
--- a/examples/valid/overlay.yaml
+++ b/examples/valid/overlay.yaml
@@ -46,3 +46,8 @@ actions:
     update:
       description: |
         This is my test description
+
+  - target: '$..schemas.*'
+    update:
+      examples:
+        - one: two

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -279,7 +279,7 @@ class API {
   serializeDefinition(outputPath?: string): string {
     if (this.overlayedDefinition) {
       const {comments} = parseWithPointers(this.rawDefinition, {attachComments: true})
-      const dumpOptions = {comments, lineWidth: Number.POSITIVE_INFINITY}
+      const dumpOptions = {comments, lineWidth: Number.POSITIVE_INFINITY, noRefs: true}
       return this.guessFormat(outputPath) === 'json'
         ? JSON.stringify(this.overlayedDefinition)
         : safeStringify(this.overlayedDefinition, dumpOptions)


### PR DESCRIPTION
Fixes #708

When outputing the overlayed result of the `bump overlay` command, we
shouldn't export yaml aliases (`*ref` used with `&ref`) as this
feature of YAML is not well supported by tools.

Also, it's not the job of the overlay command to guess whether to use
YAML anchors or not.

With this commit we make sure to output yaml without refs.