### PR TITLE
diff: support --overlay flag on diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Please check `bump deploy --help` for more usage details.
 ### The `diff` command
 
 Using the `diff` command can help to spot differences between the local API
-document and the latest deployed version. 
+document and the latest deployed version.
 
 #### Public API diffs
 
@@ -196,7 +196,7 @@ Modified: GET /consommations
 By default the command will always exit with a successful return code. If you
 want to use this command in a CI environment and want the command to fail **in
 case of a breaking change**, you will need to add the `--fail-on-breaking` flag
-to your diff command. 
+to your diff command.
 
 By default if the environment variable `CI=1` is present (in most continuous
 integration environment), the flag will be enabled. In that case you can disable
@@ -229,6 +229,14 @@ bump diff path/to/your/file.yml path/to/your/next-file.yml --doc my-documentatio
 ```
 
 Please check `bump diff --help` for full usage details.
+
+#### Diffs with overlayed source files
+
+The `bump diff` command also supports [overlays](#the-overlay-command). This means you can pass the `--overlay my-overlay-file.yml` flag to the command and it will apply the overlay on both files **before** running the diff. E.g.:
+
+```shell
+bump diff --overlay my-overlay.yml path/to/your/file.yml path/to/your/next-file.yml
+```
 
 ### The `preview` command
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -54,6 +54,7 @@ export default class Diff extends BaseCommand<typeof Diff> {
     'fail-on-breaking': flagsBuilder.failOnBreaking({allowNo: true}),
     format: flagsBuilder.format(),
     hub: flagsBuilder.hub(),
+    overlay: flagsBuilder.overlay(),
     token: flagsBuilder.token({required: false}),
   }
 
@@ -83,13 +84,14 @@ export default class Diff extends BaseCommand<typeof Diff> {
   */
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Diff)
-    const [documentation, hub, branch, token, format, expires] = [
+    const [documentation, hub, branch, token, format, expires, overlays] = [
       flags.doc,
       flags.hub,
       flags.branch,
       flags.token,
       flags.format,
       flags.expires,
+      flags.overlay,
     ]
     if (format === 'text') {
       if (args.otherFile) {
@@ -114,6 +116,7 @@ export default class Diff extends BaseCommand<typeof Diff> {
       token,
       format,
       expires,
+      overlays,
     )
 
     ux.action.stop()

--- a/src/commands/overlay.ts
+++ b/src/commands/overlay.ts
@@ -35,17 +35,17 @@ ${chalk.dim('$ bump overlay DEFINITION_FILE OVERLAY_FILE > destination/file.json
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Overlay)
     const outputPath = flags.out
+    const {file, overlay} = args
 
     ux.action.start("* Let's apply the overlay to the main definition")
 
     ux.action.status = '...loading definition file'
 
-    const api = await API.load(args.file)
+    const api = await API.load(file)
 
     ux.action.status = '...applying overlay'
 
-    await api.applyOverlay(args.overlay)
-    const [overlayedDefinition] = api.extractDefinition(outputPath)
+    const [overlayedDefinition] = await api.extractDefinition(outputPath, [overlay])
 
     ux.action.stop()
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -51,7 +51,7 @@ export default class Preview extends BaseCommand<typeof Preview> {
     currentPreview: PreviewResponse | undefined = undefined,
   ): Promise<PreviewResponse> {
     const api = await API.load(file)
-    const [definition, references] = api.extractDefinition()
+    const [definition, references] = await api.extractDefinition()
 
     this.d(`${file} looks like an ${api.specName} spec version ${api.version}`)
 

--- a/src/core/deploy.ts
+++ b/src/core/deploy.ts
@@ -52,17 +52,7 @@ export class Deploy {
     temporary?: boolean | false,
   ): Promise<VersionResponse | undefined> {
     let version: VersionResponse | undefined
-    if (overlay) {
-      /* eslint-disable no-await-in-loop */
-      // Alternatively we can apply all overlays in parallel
-      // https://stackoverflow.com/questions/48957022/unexpected-await-inside-a-loop-no-await-in-loop
-      for (const overlayFile of overlay) {
-        await api.applyOverlay(overlayFile)
-      }
-      /* eslint-enable no-await-in-loop */
-    }
-
-    const [definition, references] = api.extractDefinition()
+    const [definition, references] = await api.extractDefinition(undefined, overlay)
 
     const request: VersionRequest = {
       auto_create_documentation: autoCreate && !dryRun,

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -159,7 +159,20 @@ class API {
     this.overlayedDefinition = await new Overlay().run(currentDefinition, overlayDefinition)
   }
 
-  public extractDefinition(outputPath?: string): [string, APIReference[]] {
+  public async extractDefinition(
+    outputPath?: string,
+    overlays?: string[] | undefined,
+  ): Promise<[string, APIReference[]]> {
+    if (overlays) {
+      /* eslint-disable no-await-in-loop */
+      // Alternatively we can apply all overlays in parallel
+      // https://stackoverflow.com/questions/48957022/unexpected-await-inside-a-loop-no-await-in-loop
+      for (const overlayFile of overlays) {
+        await this.applyOverlay(overlayFile)
+      }
+      /* eslint-enable no-await-in-loop */
+    }
+
     const references = []
 
     for (let i = 0; i < this.references.length; i++) {


### PR DESCRIPTION
This commit is both a refactoring (to move the logic to apply overlays
inside the `definition.extractDefinition` to DRY the code and simplify
extracting an overlayed definition) and a new feature.

The new feature is to allow the `--overlay` flag on the `bump diff`
command to be able to apply a list of overlays to the files before
creating the diff.

The feature was asked by @JakeSCahill (thanks for asking it makes a
lot of sense to have it for the diff command too)