### PR TITLE
fix(overlay): make sure to keep track of overlay $refs

### DIFF
--- a/examples/valid/doc/error-codes.md
+++ b/examples/valid/doc/error-codes.md
@@ -1,0 +1,3 @@
+## Error code and response statuses
+
+Hello this is a referenced markdown file

--- a/examples/valid/overlay.yaml
+++ b/examples/valid/overlay.yaml
@@ -10,6 +10,9 @@ actions:
         - title: Getting started
           content: |
             Use this API directly in your browser with the API explorer!
+        - title: Error codes
+          content:
+            $ref: "../valid/doc/error-codes.md"
   - target: '$.info.description'
     description: Provide a better introduction for our end users than this techno babble.
     update: |

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -156,6 +156,12 @@ class API {
       throw new Error(`${overlayPath} does not look like an OpenAPI overlay`)
     }
 
+    for (const reference of overlay.references) {
+      // Keep overlay reference data only if there's no existing refs with the same location
+      if (this.references.every((existing) => existing.location !== reference.location)) {
+        this.references.push(reference)
+      }
+    }
     this.overlayedDefinition = await new Overlay().run(currentDefinition, overlayDefinition)
   }
 

--- a/test/commands/overlay.test.ts
+++ b/test/commands/overlay.test.ts
@@ -23,7 +23,7 @@ describe('overlay subcommand', () => {
       // Target on nodes which have "x-beta":true field
       expect(overlayedDefinition.components.schemas.Pong.properties).to.have.all.keys('pong')
       expect(overlayedDefinition.tags[0].description).to.equal('This is my test description\n')
-      expect(overlayedDefinition['x-topics'].length).to.equal(2)
+      expect(overlayedDefinition['x-topics'].length).to.equal(3)
     })
 
     it('Stores the result to the target output (and format) file argument', async () => {

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -153,6 +153,10 @@ describe('API class', () => {
 
         expect(spyOnStderr.thirdCall.args[0]).to.equal("WARNING: Action target '$.servers' has no matching elements\n")
         spyOnStderr.restore()
+
+        // Make sure overlay references are stored on the main definition
+        expect(api.references.length).to.equal(1)
+        expect(api.references[0].location).to.equal(['doc', 'error-codes.md'].join(path.sep))
       })
 
       it('preserves line width and YAML comments', async () => {
@@ -186,9 +190,15 @@ describe('API class', () => {
       })
 
       it('sets the overlayedDefinition with the given overlay URL', async () => {
-        nock('http://example.org').get('/source.yaml').replyWithFile(200, 'examples/valid/overlay.yaml', {
-          'Content-Type': 'application/yaml',
-        })
+        nock('http://example.org')
+          .get('/source.yaml')
+          .replyWithFile(200, 'examples/valid/overlay.yaml', {
+            'Content-Type': 'application/yaml',
+          })
+          .get('/valid/doc/error-codes.md')
+          .replyWithFile(200, 'examples/valid/doc/error-codes.md', {
+            'Content-Type': 'text/markdown',
+          })
 
         const api = await API.load('examples/valid/openapi.v2.json')
 


### PR DESCRIPTION
This commit is a fix to be able to keep track of references ($ref)
used inside an overlay. This make it possible to use an overlay which
references external files, and have them available for the
main (overlayed) definition.

Thanks @JakeSCahill for noticing the bug!