### PR TITLE
README: remove bump explicit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ bump --help
 The Bump.sh CLI is used to interact with your API documentation hosted on Bump.sh by using the API of developers.bump.sh
 
 VERSION
-  bump-cli/2.9.5 linux-x64 node-v20.18.1
+  bump-cli/x.y.z linux-x64 node-v20+
 
 USAGE
   $ bump [COMMAND]


### PR DESCRIPTION
Prepare next release,
replace #768 

Readme does not mention anymore the bump version in `bump --help output`