### PR TITLE
deps: upgrade jsonpathly to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "axios": "^1.7.7",
         "chalk": "^5.3.0",
         "debug": "^4.3.7",
-        "jsonpathly": "^2.0.2",
+        "jsonpathly": "^3.0.0",
         "mergician": "^2.0.2",
         "open": "^10.1.0"
       },
@@ -1094,7 +1094,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2956,7 +2955,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.1.tgz",
       "integrity": "sha512-JAuARvXOzf75L7rqLL3TIP3OmuTf7N/cjRejkGASfRJH+09180+EGbSkPWSMCns+AaYpDMI+fdaJ6QCoa3f15A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-escapes": "^4.3.2",
         "ansis": "^3.17.0",
@@ -4278,7 +4276,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4436,6 +4433,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
       "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.13.0",
         "@typescript-eslint/types": "8.13.0",
@@ -4464,6 +4462,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
       "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.13.0",
         "@typescript-eslint/visitor-keys": "8.13.0"
@@ -4481,6 +4480,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
       "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4494,6 +4494,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
       "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.13.0",
         "@typescript-eslint/visitor-keys": "8.13.0",
@@ -4522,6 +4523,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
       "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.13.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -5090,7 +5092,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5212,15 +5213,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/antlr4": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
-      "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/any-observable": {
@@ -5682,7 +5674,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -6990,7 +6981,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7119,7 +7109,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7203,7 +7192,6 @@
       "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7381,7 +7369,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -7995,6 +7982,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -10452,13 +10440,12 @@
       }
     },
     "node_modules/jsonpathly": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jsonpathly/-/jsonpathly-2.0.3.tgz",
-      "integrity": "sha512-eBlSozh2UymGpZ/zBJVwRGEDwiWZePRjIRfo5R663l5mByr3Udri9AO/yJMkpa4/b96qa95n0BuUrLE32tBQpg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpathly/-/jsonpathly-3.0.0.tgz",
+      "integrity": "sha512-1MCCdv1BJpniRPyXC8x3ofJJyZ1DpVYZtw4dRJBYNW98q8H21hV55l2bfuOHKuSCBXLXl6fPre9jcBwJxjE+ZA==",
       "license": "MIT",
-      "dependencies": {
-        "antlr4": "^4.13.2",
-        "fast-deep-equal": "^3.1.3"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/just-extend": {
@@ -12847,7 +12834,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14722,7 +14708,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14971,7 +14956,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "axios": "^1.7.7",
     "chalk": "^5.3.0",
     "debug": "^4.3.7",
-    "jsonpathly": "^2.0.2",
+    "jsonpathly": "^3.0.0",
     "mergician": "^2.0.2",
     "open": "^10.1.0"
   }

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -86,12 +86,7 @@ export class Overlay {
 
     // Take last element from path (which is the thing to act
     // upon)
-    let thingToActUpon: number | string | undefined = explodedPath.pop()
-    // The last element (e.g. '"price"]' or '0]') contains a final ']'
-    // so we need to remove it AND we need to parse the element to
-    // transform the string in either a string or a number
-    thingToActUpon =
-      thingToActUpon === undefined ? '$' : (thingToActUpon = JSON.parse(thingToActUpon.slice(0, -1)) as number | string)
+    const thingToActUpon: number | string = this.pathEntryToKey(explodedPath.pop())
 
     // Reconstruct the stringified path expression targeting the parent
     const parentPath: string = explodedPath.join('][')
@@ -115,6 +110,17 @@ export class Overlay {
 
   private humanName(action: JSONSchema4Object): string {
     return action.description ? `Action '${action.description}'` : 'Action'
+  }
+
+  // The last path entry (e.g. "'price']" or '0]') contains a final
+  // ']' so we need to remove it AND we need to replace single quotes
+  // to double quotes AND FINALLY parse the element to transform the
+  // string in either a string or a number.
+  private pathEntryToKey(pathEntry: string | undefined): number | string {
+    if (pathEntry === undefined) {
+      return '$'
+    }
+    return JSON.parse(pathEntry.slice(0, -1).replaceAll(/(^'|'$)/g, '"'))
   }
 
   private remove(parent: JSONSchema4Object, property_or_index: number | string): void {


### PR DESCRIPTION
As part of [0], it was noted that the upstream library we use for JSON
Path expressions isn't fully RFC 9535 compliant.

With help from Claude Sonnet 4.5 to help diagnose a change in the public
API for jsonpathly, where a single quoted path is returned.

[0]: https://github.com/atamano/jsonpathly/issues/12



Also:

- **chore: update lockfile after `npm install`**
