### PR TITLE
api: use token based authorization method

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -49,7 +49,7 @@ class BumpApi {
     this.client.put<PreviewResponse>(`/previews/${versionId}`, body)
 
   private authorizationHeader = (token: string) => ({
-    Authorization: `Basic ${Buffer.from(token).toString('base64')}`,
+    Authorization: `Token ${token}`,
   })
 
   private handleError = (error: AxiosError) => Promise.reject(new APIError(error))

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -30,7 +30,7 @@ describe('BumpApi HTTP client class', () => {
 
       await new BumpApi(config).postVersion({definition: '', documentation: 'hello'}, 'my-secret-token')
 
-      expect(matchAuthorizationHeader.firstCall.args[0]).to.equal('Basic bXktc2VjcmV0LXRva2Vu')
+      expect(matchAuthorizationHeader.firstCall.args[0]).to.equal('Token my-secret-token')
     })
   })
 


### PR DESCRIPTION
We've depreacted the basic auth in our API, let's use the new token
based authorization