### PR TITLE
overlay: deduplicate arrays during deep merge

### DIFF
--- a/examples/valid/enum/base-spec-nested.yaml
+++ b/examples/valid/enum/base-spec-nested.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /items/{id}:
+    put:
+      summary: Update item
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                config:
+                  type: object
+                  properties:
+                    method:
+                      type: string
+                      enum: [GET, POST]
+      responses:
+        '200':
+          description: Success

--- a/examples/valid/enum/overlay-duplicate.yaml
+++ b/examples/valid/enum/overlay-duplicate.yaml
@@ -1,0 +1,11 @@
+overlay: 1.0.0
+info:
+  title: Update config with overlapping enum values
+  version: 1.0.0
+actions:
+  - target: $.paths['/items/{id}'].put.requestBody.content['application/json'].schema.properties.config
+    update:
+      properties:
+        method:
+          type: string
+          enum: [POST, PUT, DELETE]

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -139,7 +139,7 @@ export class Overlay {
   ): APIDefinition {
     try {
       // Deep merge objects using a module (built-in spread operator is only shallow)
-      const merger = mergician({appendArrays: true})
+      const merger = mergician({appendArrays: true, dedupArrays: true})
       if (property_or_index === '$') {
         // You can't actually merge an update on a root object
         // target with the jsonpathly lib, this is just us merging

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -183,6 +183,17 @@ describe('API class', () => {
         stub(process.stderr, 'write')
       })
 
+      it('deduplicates enum arrays when merging overlapping values', async () => {
+        const api = await API.load('examples/valid/enum/base-spec-nested.yaml')
+        await api.applyOverlay('examples/valid/enum/overlay-duplicate.yaml')
+
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        const overlayed = api.overlayedDefinition as any
+        const {schema} = overlayed.paths['/items/{id}'].put.requestBody.content['application/json']
+
+        expect(schema.properties.config.properties.method.enum).to.deep.equal(['GET', 'POST', 'PUT', 'DELETE'])
+      })
+
       it('sets the overlayedDefinition with the given overlay file path', async () => {
         const api = await API.load('examples/valid/openapi.v2.json')
 


### PR DESCRIPTION
fixes #792 