### PR TITLE
deploy(arazzo): send associated openapi sources during workflow deployments

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -23,8 +23,9 @@ export interface PreviewRequest {
 }
 
 export interface Reference {
-  content?: string
-  location?: string
+  content: string
+  location: string
+  name?: string
 }
 
 export interface VersionRequest {
@@ -82,6 +83,10 @@ export interface DiffItem {
 
 export interface WorkflowVersionRequest {
   definition: string // workflowDefinition
+  // List of API references attached to the
+  // workflow (source descriptions in Arazzo
+  // vocabulary)
+  references?: Reference[]
 }
 
 export interface WorkflowVersionResponse {

--- a/src/core/workflow-deploy.ts
+++ b/src/core/workflow-deploy.ts
@@ -50,9 +50,9 @@ export class WorkflowDeploy {
   ): Promise<WorkflowVersionResponse | undefined> {
     let version: WorkflowVersionResponse | undefined
 
-    const request: WorkflowVersionRequest = {
-      definition: workflowDefinition.rawDefinition,
-    }
+    const [definition, references] = await workflowDefinition.extractDefinition()
+
+    const request: WorkflowVersionRequest = {definition, references}
 
     // eslint-disable-next-line prefer-const
     version = await this.createWorkflowVersion(mcpServer, request, token)

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -3,6 +3,8 @@ import {expect} from 'chai'
 import nock from 'nock'
 import {stub} from 'sinon'
 
+import {API} from '../../src/definition'
+
 nock.disableNetConnect()
 
 process.env.BUMP_TOKEN = process.env.BUMP_TOKEN || 'BAR'
@@ -110,11 +112,38 @@ describe('deploy subcommand', () => {
   })
 
   describe('Successful runs with MCP server', () => {
-    it('sends new workflow definition to Bump', async () => {
+    it('sends new workflow definition (flower) to Bump', async () => {
       nock('https://bump.sh').post('/api/v1/mcp_servers/crab/deploy').reply(201, {})
 
       const {stderr, stdout} = await runCommand(
         ['deploy', 'examples/valid/flower/parking.yml', '--mcp-server', 'crab'].join(' '),
+      )
+
+      expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")
+      expect(stdout).to.contain(
+        'Your crab MCP server...has received a new workflow definition which will soon be ready.',
+      )
+    })
+
+    it('sends new workflow definition with openapi sources (arazzo) to Bump', async () => {
+      const [definition, references] = await (
+        await API.load('examples/valid/arazzo/wikimedia.json')
+      ).extractDefinition()
+      nock('https://bump.sh')
+        .post('/api/v1/mcp_servers/crab/deploy', (body) => {
+          const {content: expectedContent, location: expectedLocation, name: expectedName} = references[0]
+          const {content: actualContent, location: actualLocation, name: actualName} = body.references[0]
+          return (
+            body.definition === definition &&
+            expectedContent === actualContent &&
+            expectedName === actualName &&
+            expectedLocation === actualLocation
+          )
+        })
+        .reply(201, {})
+
+      const {stderr, stdout} = await runCommand(
+        ['deploy', 'examples/valid/arazzo/wikimedia.json', '--mcp-server', 'crab'].join(' '),
       )
 
       expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")


### PR DESCRIPTION
This commit adapts the workflow deploy API call to send both the
workflow definition AND it's list of “references” (the list of openapi
dependencies from the `sourceDescriptions` of arazzo workflows)