### PR TITLE
Fix tiret on mcp-server deployment endpoint

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,7 +39,7 @@ class BumpApi {
     body: WorkflowVersionRequest,
     token: string,
   ): Promise<AxiosResponse<WorkflowVersionResponse>> =>
-    this.client.post<WorkflowVersionResponse>(`/mcp_servers/${mcpServerIdOrSlug}/deploy`, body, {
+    this.client.post<WorkflowVersionResponse>(`/mcp-servers/${mcpServerIdOrSlug}/deploy`, body, {
       headers: this.authorizationHeader(token),
     })
 

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -113,7 +113,7 @@ describe('deploy subcommand', () => {
 
   describe('Successful runs with MCP server', () => {
     it('sends new workflow definition (flower) to Bump', async () => {
-      nock('https://bump.sh').post('/api/v1/mcp_servers/crab/deploy').reply(201, {})
+      nock('https://bump.sh').post('/api/v1/mcp-servers/crab/deploy').reply(201, {})
 
       const {stderr, stdout} = await runCommand(
         ['deploy', 'examples/valid/flower/parking.yml', '--mcp-server', 'crab'].join(' '),
@@ -130,7 +130,7 @@ describe('deploy subcommand', () => {
         await API.load('examples/valid/arazzo/wikimedia.json')
       ).extractDefinition()
       nock('https://bump.sh')
-        .post('/api/v1/mcp_servers/crab/deploy', (body) => {
+        .post('/api/v1/mcp-servers/crab/deploy', (body) => {
           const {content: expectedContent, location: expectedLocation, name: expectedName} = references[0]
           const {content: actualContent, location: actualLocation, name: actualName} = body.references[0]
           return (
@@ -153,7 +153,7 @@ describe('deploy subcommand', () => {
     })
 
     it('sends unchanged workflow definition to Bump', async () => {
-      nock('https://bump.sh').post('/api/v1/mcp_servers/crab/deploy').reply(204)
+      nock('https://bump.sh').post('/api/v1/mcp-servers/crab/deploy').reply(204)
 
       const {stderr, stdout} = await runCommand(
         ['deploy', 'examples/valid/flower/parking.yml', '--mcp-server', 'crab'].join(' '),


### PR DESCRIPTION
On Bump API, 
endpoint `POST /mcp-servers/{mcp_server_id_or_slug}/deploy`
is replaced by
`POST /mcp_servers/{mcp_server_id_or_slug}/deploy`
with PR https://github.com/bump-sh/bump/pull/8414

[cf API documentation](https://developers.bump.sh/operation/operation-post-mcp_servers-parameter-deploy)

---

To be merge and released, after release of https://github.com/bump-sh/bump/pull/8414 (until that, CI here is broken)
