### PR TITLE
Fix arrays vs enum merge

### DIFF
--- a/examples/valid/enum/base-spec-nested.yaml
+++ b/examples/valid/enum/base-spec-nested.yaml
@@ -14,6 +14,7 @@ paths:
               properties:
                 config:
                   type: object
+                  x-values: [base, test]
                   properties:
                     method:
                       type: string

--- a/examples/valid/enum/overlay-duplicate.yaml
+++ b/examples/valid/enum/overlay-duplicate.yaml
@@ -5,6 +5,7 @@ info:
 actions:
   - target: $.paths['/items/{id}'].put.requestBody.content['application/json'].schema.properties.config
     update:
+      x-values: [base, overlay]
       properties:
         method:
           type: string

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -112,6 +112,19 @@ export class Overlay {
     return action.description ? `Action '${action.description}'` : 'Action'
   }
 
+  // Deep merge objects using a module (built-in spread operator is only shallow)
+  private mergeWithEnumDedup(target: JSONSchema4Object, update: JSONSchema4Object): JSONSchema4Object {
+    const merger = mergician({
+      afterEach(options: {key: string; mergeVal: unknown}) {
+        if (options.key === 'enum' && Array.isArray(options.mergeVal)) {
+          return [...new Set(options.mergeVal)]
+        }
+      },
+      appendArrays: true,
+    })
+    return merger(target, update) as JSONSchema4Object
+  }
+
   // The last path entry (e.g. "'price']" or '0]') contains a final
   // ']' so we need to remove it AND we need to replace single quotes
   // to double quotes AND FINALLY parse the element to transform the
@@ -138,13 +151,11 @@ export class Overlay {
     property_or_index: number | string,
   ): APIDefinition {
     try {
-      // Deep merge objects using a module (built-in spread operator is only shallow)
-      const merger = mergician({appendArrays: true, dedupArrays: true})
       if (property_or_index === '$') {
         // You can't actually merge an update on a root object
         // target with the jsonpathly lib, this is just us merging
         // the given update with the whole spec.
-        spec = merger(spec, update)
+        spec = this.mergeWithEnumDedup(spec, update as JSONSchema4Object) as APIDefinition
       } else if (property_or_index !== undefined) {
         const targetObject = parent[property_or_index]
 
@@ -152,7 +163,7 @@ export class Overlay {
           parent[property_or_index] =
             Array.isArray(targetObject) && Array.isArray(update)
               ? [...targetObject, ...update]
-              : merger(targetObject, update)
+              : this.mergeWithEnumDedup(targetObject as JSONSchema4Object, update as JSONSchema4Object)
         } else {
           parent[property_or_index] = update
         }

--- a/test/unit/definition.test.ts
+++ b/test/unit/definition.test.ts
@@ -219,7 +219,10 @@ describe('API class', () => {
         const overlayed = api.overlayedDefinition as any
         const {schema} = overlayed.paths['/items/{id}'].put.requestBody.content['application/json']
 
+        // enum arrays are deduped
         expect(schema.properties.config.properties.method.enum).to.deep.equal(['GET', 'POST', 'PUT', 'DELETE'])
+        // other arrays are still appended (not deduped)
+        expect(schema.properties.config['x-values']).to.deep.equal(['base', 'test', 'base', 'overlay'])
       })
 
       it('sets the overlayedDefinition with the given overlay file path', async () => {


### PR DESCRIPTION
Add an `afterEach` parameter to the `mergician` function to ensure:
 - Arrays are appended (not deduped)
 - Enums are deduped

Fixes #818 (arrays deduped) with an evolution of #791 (deduplicate enum)