### PR TITLE
Redirection developers.bump.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using [OpenAPI](https://github.com/OAI/OpenAPI-Specification) (v3.x and v2.0) or
 - Validate an API document before publishing to your documentation.
 - [Publish an API document](#the-deploy-command) to your Bump.sh documentation or hubs.
 - [Compare two API documents](#the-diff-command) to generate a human-readable diff from your API definition.
-Under the hood, it uses the API of [developers.bump.sh](https://developers.bump.sh). And is built with the [`oclif`](https://oclif.io) framework in Typescript.
+Under the hood, it uses the workspace API of [developers.bump.sh](https://developers.bump.sh/doc/workspace/). And is built with the [`oclif`](https://oclif.io) framework in Typescript.
 
 Using [Flower](https://docs.bump.sh/help/mcp-servers/specification-support/flower-support/) or [Arazzo](https://docs.bump.sh/arazzo/v1.0/), you can:
 
@@ -83,7 +83,7 @@ npx bump --help
 
 ### Can I install Bump.sh CLI without using NodeJS?
 
-Unfortunately, at the moment we only support the Node environment. However, you can download a standalone package directly from the [latest Github release](https://github.com/bump-sh/cli/releases) assets which you can run as a standalone binary. Or you can push your documentation using [our API](https://developers.bump.sh/) (advanced usage only).
+Unfortunately, at the moment we only support the Node environment. However, you can download a standalone package directly from the [latest Github release](https://github.com/bump-sh/cli/releases) assets which you can run as a standalone binary. Or you can push your documentation using [our API](https://developers.bump.sh/doc/workspace/) (advanced usage only).
 
 ## Usage
 
@@ -284,7 +284,7 @@ bump preview path/to/file.json
 You can also preview a document available via a URL:
 
 ```shell
-bump preview https://developers.bump.sh/source.yaml
+bump preview https://developers.bump.sh/doc/workspace/source.yaml
 ```
 
 #### Live preview
@@ -384,7 +384,7 @@ For example to generate a preview:
   > Your preview is visible at: https://bump.sh/preview/42
   ```
 
-Please note that even if CLI is running locally, by default requests are sent to [Bump.sh API](https://developers.bump.sh/).
+Please note that even if CLI is running locally, by default requests are sent to [Bump.sh API](https://developers.bump.sh/doc/workspace/).
 
 If you have a local version of the Bump.sh API, you can run CLI 100% in local environment
 by setting the environment variable `BUMP_HOST`:

--- a/examples/valid/openapi.v3.2.yml
+++ b/examples/valid/openapi.v3.2.yml
@@ -603,7 +603,7 @@ components:
         humanUrl:
           type: string
           description: public documentation URL
-          example: https://developers.bump.sh/
+          example: https://developers.bump.sh/doc/workspace/
         tags:
           type: array
           items:
@@ -635,7 +635,7 @@ components:
                 description: Content of the extra property (`data` or `url`)
             example:
               type: "OpenAPI"
-              url: "https://developers.bump.sh/source.json"
+              url: "https://developers.bump.sh/doc/workspace/source.json"
         created:
           type: date
           description: Creation date of this API
@@ -751,11 +751,11 @@ components:
         previous_version_url:
           type: string
           description: URL of previous version specification, in JSON format
-          example: https://developers.bump.sh/changes/750f15d8/previous.json
+          example: https://developers.bump.sh/doc/workspace/changes/750f15d8/previous.json
         current_version_url:
           type: string
           description: URL of current version specification, in JSON format
-          example: https://developers.bump.sh/changes/750f15d8/current.json
+          example: https://developers.bump.sh/doc/workspace/changes/750f15d8/current.json
     DiffItem:
       properties:
         id:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bump-cli",
-  "description": "The Bump CLI is used to interact with your API documentation hosted on Bump.sh by using the API of developers.bump.sh",
+  "description": "The Bump CLI is used to interact with your API documentation hosted on Bump.sh by using the APIs of developers.bump.sh",
   "version": "2.10.0",
   "author": "Paul Bonaud <paulr@bump.sh>",
   "bin": {

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -1,5 +1,5 @@
 /*
-   Please see https://developers.bump.sh/ for the API documentation
+   Please see https://developers.bump.sh/doc/workspace/ for the API documentation
    The types defined here should align with the API definition
 */
 export interface PingResponse {

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -192,14 +192,14 @@ describe('deploy subcommand', () => {
         .post('/api/v1/versions', (body) => body.documentation === 'coucou' && !body.branch_name)
         .reply(201, {doc_public_url: 'http://localhost/doc/1'})
 
-      nock('https://developers.bump.sh')
+      nock('https://developers.bump.sh/doc/workspace/')
         .get('/source.json')
         .replyWithFile(200, 'examples/valid/asyncapi.no-refs.v2.yml', {
           'Content-Type': 'application/json',
         })
 
       const {stdout} = await runCommand(
-        ['deploy', 'https://developers.bump.sh/source.json', '--doc', 'coucou'].join(' '),
+        ['deploy', 'https://developers.bump.sh/doc/workspace/source.json', '--doc', 'coucou'].join(' '),
       )
       expect(stdout).to.contain(
         'Your coucou documentation...has received a new deployment which will soon be ready at:\nhttp://localhost/doc/1',


### PR DESCRIPTION
We'll move our Bump.sh documentation in hub, and transfer the custom domain from a Api to a Hub:

https://developers.bump.sh/ -> https://developers.bump.sh/doc/workspace/

Most of these changes will be ensured [via redirection](https://itducks.slack.com/archives/C08294CTDM3/p1780661912150059),
 but let's be as clean and consistent as possible.