### PR TITLE
Improve docName and mcpServerName

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -66,7 +66,6 @@ export interface DiffRequest {
 export interface DiffResponse {
   breaking?: boolean
   details?: DiffItem[]
-  doc_name?: string
   html?: string
   id: string
   markdown?: string

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -42,6 +42,7 @@ export interface VersionRequest {
 }
 
 export interface VersionResponse {
+  doc_name: string
   doc_public_url?: string
   id: string
 }
@@ -65,6 +66,7 @@ export interface DiffRequest {
 export interface DiffResponse {
   breaking?: boolean
   details?: DiffItem[]
+  doc_name?: string
   html?: string
   id: string
   markdown?: string
@@ -92,4 +94,5 @@ export interface WorkflowVersionRequest {
 export interface WorkflowVersionResponse {
   id: string
   mcp_server_id: string
+  mcp_server_name: string
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -174,17 +174,18 @@ ${chalk.dim('$ bump deploy FILE --mcp-server <your_mcp_server_id_or_slug> --toke
       overlay,
       temporary,
     )
+    const docName = response?.doc_name || documentation
 
     if (dryRun) {
       ux.stdout(ux.colorize('green', 'Definition is valid'))
     } else if (response) {
-      process.stdout.write(ux.colorize('green', `Your ${documentation} documentation...`))
+      process.stdout.write(ux.colorize('green', `Your ${docName} documentation...`))
       ux.stdout(
         ux.colorize('green', `has received a new ${temporary ? 'preview' : 'deployment'} which will soon be ready at:`),
       )
       ux.stdout(ux.colorize('underline', response.doc_public_url!))
     } else {
-      ux.warn(`Your ${documentation} documentation has not changed`)
+      ux.warn(`Your ${docName} documentation has not changed`)
     }
   }
 
@@ -196,9 +197,10 @@ ${chalk.dim('$ bump deploy FILE --mcp-server <your_mcp_server_id_or_slug> --toke
       mcpServer,
       token,
     )
+    const mcpServerName = response?.mcp_server_name || mcpServer
 
     if (response) {
-      process.stdout.write(ux.colorize('green', `Your ${mcpServer} MCP server...`))
+      process.stdout.write(ux.colorize('green', `Your ${mcpServerName} MCP server...`))
       ux.stdout(ux.colorize('green', `has received a new workflow definition which will soon be ready.`))
     } else {
       ux.warn(`Your ${mcpServer} MCP server has not changed.`)

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -113,6 +113,7 @@ export class Diff {
     return {
       breaking: versionWithDiff.diff_breaking,
       details: versionWithDiff.diff_details,
+      doc_name: versionWithDiff.doc_name,
       id: versionWithDiff.id,
       markdown: versionWithDiff.diff_markdown,
       public_url: versionWithDiff.diff_public_url,

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -7,6 +7,10 @@ import {BumpApi} from '../api/index.js'
 import {DiffRequest, DiffResponse, VersionRequest, VersionResponse, WithDiff} from '../api/models.js'
 import {API} from '../definition.js'
 
+export interface DiffResult extends DiffResponse {
+  doc_name?: string
+}
+
 export class Diff {
   // 120 seconds = 2 minutes
   static readonly TIMEOUT = 120
@@ -108,7 +112,7 @@ export class Diff {
     return debug(`bump-cli:core:diff`)(formatter, ...args)
   }
 
-  extractDiff(versionWithDiff: VersionResponse & WithDiff): DiffResponse {
+  extractDiff(versionWithDiff: VersionResponse & WithDiff): DiffResult {
     // TODO: return a real diff_id in the GET /version API
     return {
       breaking: versionWithDiff.diff_breaking,
@@ -145,7 +149,7 @@ export class Diff {
     expires?: string | undefined,
     overlays1?: string[] | undefined,
     overlays2?: string[] | undefined,
-  ): Promise<DiffResponse | undefined> {
+  ): Promise<DiffResult | undefined> {
     if (!this._config) this._config = await Config.load(resolve(import.meta.dirname, './../../'))
 
     let diffVersion: DiffResponse | VersionResponse | undefined
@@ -183,13 +187,14 @@ export class Diff {
   }
 
   async waitResult(
-    result: DiffResponse | VersionResponse,
+    apiResponse: DiffResponse | VersionResponse,
     token: string | undefined,
     opts: {format: string; timeout: number},
-  ): Promise<DiffResponse> {
-    const pollingResponse = await (this.isVersion(result) && token
-      ? this.bumpClient.getVersion(result.id, token)
-      : this.bumpClient.getDiff(result.id, opts.format))
+  ): Promise<DiffResult> {
+    let diffResult: DiffResult = {id: apiResponse.id}
+    const pollingResponse = await (this.isVersion(apiResponse) && token
+      ? this.bumpClient.getVersion(apiResponse.id, token)
+      : this.bumpClient.getDiff(apiResponse.id, opts.format))
 
     if (opts.timeout <= 0) {
       throw new CLIError(
@@ -199,22 +204,20 @@ export class Diff {
 
     switch (pollingResponse.status) {
       case 200: {
-        let diff: DiffResponse | (VersionResponse & WithDiff) = pollingResponse.data
+        const diff: DiffResponse | (VersionResponse & WithDiff) = pollingResponse.data
 
-        if (this.isVersionWithDiff(diff)) {
-          diff = this.extractDiff(diff)
-        }
+        diffResult = this.isVersionWithDiff(diff) ? this.extractDiff(diff) : diff
 
         this.d('Received diff:')
-        this.d(diff)
-        return diff
+        this.d(diffResult)
+        return diffResult
         break
       }
 
       case 202: {
         this.d('Waiting 1 sec before next poll')
         await this.pollingDelay()
-        return this.waitResult(result, token, {
+        return this.waitResult(apiResponse, token, {
           format: opts.format,
           timeout: opts.timeout - 1,
         })
@@ -222,7 +225,7 @@ export class Diff {
       }
     }
 
-    return {} as DiffResponse
+    return diffResult
   }
 
   private async delay(ms: number): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export const COMMANDS = {
   preview: Preview,
 }
 
-export {DiffResponse, PreviewResponse, VersionResponse, WithDiff} from './api/models.js'
+export {PreviewResponse, VersionResponse, WithDiff} from './api/models.js'
 
 export {default as Deploy} from './commands/deploy.js'
 export {default as Preview} from './commands/preview.js'

--- a/test/commands/deploy.test.ts
+++ b/test/commands/deploy.test.ts
@@ -41,6 +41,20 @@ describe('deploy subcommand', () => {
       expect(stdout).to.contain('http://localhost/doc/1')
     })
 
+    it('sends new version to Bump, and use docName from response', async () => {
+      nock('https://bump.sh')
+        .post('/api/v1/versions', (body) => body.documentation === '42' && !body.branch_name)
+        .reply(201, {doc_name: 'Cou Cou', doc_public_url: 'http://localhost/doc/1'})
+
+      const {stderr, stdout} = await runCommand(['deploy', 'examples/valid/openapi.v3.json', '--doc', '42'].join(' '))
+
+      expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")
+      expect(stdout).to.contain(
+        'Your Cou Cou documentation...has received a new deployment which will soon be ready at:',
+      )
+      expect(stdout).to.contain('http://localhost/doc/1')
+    })
+
     it('sends new version to Bump on given branch', async () => {
       nock('https://bump.sh')
         .post('/api/v1/versions', (body) => body.documentation === 'coucou' && body.branch_name === 'next')
@@ -122,6 +136,19 @@ describe('deploy subcommand', () => {
       expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")
       expect(stdout).to.contain(
         'Your crab MCP server...has received a new workflow definition which will soon be ready.',
+      )
+    })
+
+    it('sends new workflow definition (flower) to Bump, and display doc name', async () => {
+      nock('https://bump.sh').post('/api/v1/mcp-servers/crab/deploy').reply(201, {mcp_server_name: 'Flower Power'})
+
+      const {stderr, stdout} = await runCommand(
+        ['deploy', 'examples/valid/flower/parking.yml', '--mcp-server', 'crab'].join(' '),
+      )
+
+      expect(stderr).to.contain("Let's deploy on Bump.sh... done\n")
+      expect(stdout).to.contain(
+        'Your Flower Power MCP server...has received a new workflow definition which will soon be ready.',
       )
     })
 


### PR DESCRIPTION
We know commands bump deploy --doc (or --mcp-server) can receive an `id`,
and we don't want this id to be used as CLI output

So we can use the doc_name (for API version),
and mcp_server_name (for MCP Server version),
that can be returned by the Bump.sh workflow API:
cf https://github.com/bump-sh/bump/pull/8623